### PR TITLE
Fix bug for unhandled Add to Cart errors

### DIFF
--- a/src/app/base/tests/base.test.js
+++ b/src/app/base/tests/base.test.js
@@ -17,7 +17,7 @@ describe('Base', function() {
 
     describe('base', function() {
         it ("should display the correct title", function() {
-            expect(page.getTitle()).toBe('OrderCloud');
+            expect(page.getTitle()).toBe('Angular Buyer');
         });
     })
 });

--- a/src/app/common/services/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems.js
@@ -45,10 +45,14 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloud) {
             Specs: _specConvert(product.Specs)
         };
         li.ShippingAddressID = isSingleShipping(order) ? getSingleShippingAddressID(order) : null;
-        OrderCloud.LineItems.Create(order.ID, li).then(function(lineItem) {
-            $rootScope.$broadcast('OC:UpdateOrder', order.ID);
-            deferred.resolve();
-        });
+        OrderCloud.LineItems.Create(order.ID, li)
+            .then(function(lineItem) {
+                $rootScope.$broadcast('OC:UpdateOrder', order.ID);
+                deferred.resolve();
+            })
+            .catch(function(error) {
+                deferred.reject(error);
+            });
 
         function isSingleShipping(order) {
             return _.pluck(order.LineItems, 'ShippingAddressID').length == 1;

--- a/src/app/common/tests/oc-lineitems.spec.js
+++ b/src/app/common/tests/oc-lineitems.spec.js
@@ -1,0 +1,42 @@
+describe('Factory: ocLineItem', function() {
+    var scope,
+        q,
+        oc,
+        _ocLineItems,
+        order = {
+            ID: "FAKE_ORDER_ID",
+            LineItems: []
+        },
+        product = {
+            ID: "FAKE_PRODUCT_ID",
+            Quantity: 2
+        };
+    beforeEach(module('orderCloud'));
+    beforeEach(module('orderCloud.sdk'));
+    beforeEach(inject(function($rootScope, $q, OrderCloud, ocLineItems) {
+        scope = $rootScope.$new();
+        q = $q;
+        oc = OrderCloud;
+        _ocLineItems = ocLineItems;
+    }));
+    describe('AddItem', function() {
+        it ('should start up a new $q.defer()', function() {
+            spyOn(q, 'defer').and.callThrough();
+            _ocLineItems.AddItem(order, product);
+            expect(q.defer).toHaveBeenCalled();
+        });
+        it ('should call OrderCloud.LineItems.Create()', function() {
+            var defer = q.defer();
+            defer.resolve("NEW_LINE_ITEM");
+            spyOn(oc.LineItems, 'Create').and.returnValue(defer.promise);
+
+            _ocLineItems.AddItem(order, product);
+            expect(oc.LineItems.Create).toHaveBeenCalledWith(order.ID, {
+                ProductID: product.ID,
+                Quantity: product.Quantity,
+                Specs: [],
+                ShippingAddressID: null
+            });
+        });
+    });
+});


### PR DESCRIPTION
ocLineItems.AddItem() was not handling errors from the OrderCloud SDK properly
It now passes the error back through to the original promise so that the product detail
controller can send it to the $exceptionHandler

CCN-255