### PR TITLE
My payments performance updates

### DIFF
--- a/src/app/common/services/oc-authnet.js
+++ b/src/app/common/services/oc-authnet.js
@@ -72,7 +72,6 @@ function AuthorizeNet( $q, $resource, OrderCloud) {
             }
         }).callApi(requestBody).$promise
             .then(function(data) {
-                console.log(data);
                 d.resolve(data);
             })
             .catch(function(ex) {

--- a/src/app/myPayments/myPayments.js
+++ b/src/app/myPayments/myPayments.js
@@ -36,34 +36,31 @@ function MyPaymentsController($q, $state, toastr, $exceptionHandler, ocConfirm, 
 
     vm.createCreditCard = function(){
         MyPaymentCreditCardModal.Create()
-        .then(function() {
+        .then(function(data) {
             toastr.success('Credit Card Created', 'Success');
-            $state.reload('myPayments');
+            vm.personalCreditCards.Items.push(data);
         });
     };
 
-    vm.edit = function(creditCard){
-        MyPaymentCreditCardModal.Edit(creditCard)
-            .then(function(){
+    vm.edit = function(scope){
+        MyPaymentCreditCardModal.Edit(scope.creditCard)
+            .then(function(data){
                 toastr.success('Credit Card Updated', 'Success');
-                $state.reload('myPayments');
+                vm.personalCreditCards.Items[scope.$index] = data;
             });
     };
 
-    vm.delete = function(creditCard){
-
+    vm.delete = function(scope){
         ocConfirm.Confirm("Are you sure you want to delete this Credit Card?")
             .then(function(){
-                var df = $q.defer();
-                df.templateUrl = 'common/templates/view.loading.tpl.html';
-                df.message = 'Deleting Selected Credit Card';
-                vm.loading = df;
-
-                ocAuthNet.DeleteCreditCard(creditCard)
+                vm.loading = {
+                    templateUrl: 'common/templates/view.loading.tpl.html',
+                    message: 'Deleting Selected Credit Card'
+                };
+                vm.loading.promise = ocAuthNet.DeleteCreditCard(scope.creditCard)
                     .then(function(){
                         toastr.success('Credit Card Deleted', 'Success');
-                        df.resolve();
-                        $state.reload('myPayments');
+                        vm.personalCreditCards.Items.splice(scope.$index, 1);
                     })
                     .catch(function(error) {
                         $exceptionHandler(error);

--- a/src/app/myPayments/templates/myPayments.tpl.html
+++ b/src/app/myPayments/templates/myPayments.tpl.html
@@ -1,28 +1,31 @@
-<article id="myPayments" cg-busy="myPayments.loading">
-    <!--PERSONAL CREDIT CARDS-->
-    <button class="btn btn-primary pull-right" ng-click="myPayments.createCreditCard()"><i
-            class="fa fa-plus-circle"></i> New Credit Card
-    </button>
-    <h3><i class="fa fa-credit-card"></i> Personal Credit Cards</h3>
-    <hr>
-    <div class="panel panel-default" ng-repeat="creditCard in myPayments.personalCreditCards.Items">
-        <div class="panel-body">
-            <div class="row">
-                <div class="col-xs-2 col-sm-1 text-center">
-                    <i class="fa fa-2x {{creditCard.CardType | faCreditCard}}"></i>
-                </div>
-                <div class="col-xs-6 col-sm-8">
-                    <b>{{creditCard.CardholderName}}</b> <br ng-if="creditCard.CardholderName">
-                    <span class="text-muted">{{'XXXX-XXXX-XXXX-' + creditCard.PartialAccountNumber}}</span><br>
-                    <small class="text-muted">Expires On: {{creditCard.ExpirationDate | date:'MM/yy'}}</small>
-                </div>
-                <div class="col-xs-4 col-sm-3 text-right">
-                    <a href="" ng-click="myPayments.delete(creditCard)">Delete</a> |
-                    <a href="" ng-click="myPayments.edit(creditCard)">Edit</a>
+<article id="myPayments">
+    <div cg-busy="myPayments.loading">
+        <!--PERSONAL CREDIT CARDS-->
+        <button class="btn btn-primary pull-right" ng-click="myPayments.createCreditCard()"><i
+                class="fa fa-plus-circle"></i> New Credit Card
+        </button>
+        <h3><i class="fa fa-credit-card"></i> Personal Credit Cards</h3>
+        <hr>
+        <div class="panel panel-default" ng-repeat="creditCard in myPayments.personalCreditCards.Items">
+            <div class="panel-body">
+                <div class="row">
+                    <div class="col-xs-2 col-sm-1 text-center">
+                        <i class="fa fa-2x {{creditCard.CardType | faCreditCard}}"></i>
+                    </div>
+                    <div class="col-xs-6 col-sm-8">
+                        <b>{{creditCard.CardholderName}}</b> <br ng-if="creditCard.CardholderName">
+                        <span class="text-muted">{{'XXXX-XXXX-XXXX-' + creditCard.PartialAccountNumber}}</span><br>
+                        <small class="text-muted">Expires On: {{creditCard.ExpirationDate | date:'MM/yy'}}</small>
+                    </div>
+                    <div class="col-xs-4 col-sm-3 text-right">
+                        <a href="" ng-click="myPayments.delete(this)">Delete</a> |
+                        <a href="" ng-click="myPayments.edit(this)">Edit</a>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
+
     <div class="no-matches" ng-if="!myPayments.personalCreditCards">
         You have not created any personal credit cards. <br>
         <a href="" ng-click="myPayments.createCreditCard()">Creat one now!</a>

--- a/src/app/myPayments/tests/myPayments.spec.js
+++ b/src/app/myPayments/tests/myPayments.spec.js
@@ -39,7 +39,12 @@ describe('Component: myPayments', function() {
             confirm,
             creditCardModal,
             authNet,
-            mockCreditCard
+            mockCreditCard,
+            mockSpendingAccount,
+            mockGiftCard,
+            mockCCresponse,
+            mockSAresponse,
+            mockGCresponse
         ;
 
         beforeEach(inject(function($controller, $q, $state, toastr, $exceptionHandler, ocConfirm, ocAuthNet, MyPaymentCreditCardModal) {
@@ -50,7 +55,7 @@ describe('Component: myPayments', function() {
             authNet = ocAuthNet;
             mockCreditCard =   {
                 "ID": "testCompanyACard",
-                "Editable": false,
+                "Editable": true,
                 "Token": null,
                 "DateCreated": "2016-12-07T17:49:28.73+00:00",
                 "CardType": "visa",
@@ -79,49 +84,57 @@ describe('Component: myPayments', function() {
                     "EndDate": "2017-02-02T00:00:00+00:00",
                     "xp": null
             };
+            mockCCresponse = {Items:[mockCreditCard]};
+            mockSAresponse = {Items:[mockSpendingAccount]};
+            mockGCresponse = {Items:[mockGiftCard]};
             creditCardModal = MyPaymentCreditCardModal;
             myPaymentCtrl = $controller('MyPaymentsCtrl', {
                 $scope : scope,
                 $state : state,
                 toastr : toaster,
-                UserCreditCards : mockCreditCard,
+                UserCreditCards : mockCCresponse,
                 MyPaymentCreditCardModal : creditCardModal,
-                ocConfirm : ocConfirm,
+                ocConfirm : confirm,
                 $exceptionHandler: exceptionHandler,
-                UserSpendingAccounts : mockSpendingAccount,
-                GiftCards : mockGiftCard,
+                UserSpendingAccounts : mockSAresponse,
+                GiftCards : mockGCresponse,
                 ocAuthNet: authNet
             });
-            spyOn(state, 'reload');
+            //spyOn(state, 'reload');
             spyOn(toaster, 'success');
         }));
+        it ('should initialize the view model of the controller', function() {
+            expect(myPaymentCtrl.personalCreditCards).toEqual(mockCCresponse);
+            expect(myPaymentCtrl.personalSpendingAccounts).toEqual(mockSAresponse);
+            expect(myPaymentCtrl.giftCards).toEqual(mockGCresponse);
+        });
         describe('Create Credit Card', function(){
             beforeEach(function(){
                 var df = q.defer();
-                df.resolve();
+                df.resolve("NEW_CREDIT_CARD");
                 spyOn(creditCardModal, 'Create').and.returnValue(df.promise);
                 // spyOn(oc.Payments, 'List').and.returnValue(df.promise);
                 myPaymentCtrl.createCreditCard();
             });
-            it('should call the create credit card modal then reload the state and display success toastr', function(){
+            it('should call the create credit card modal and add the new credit card to the view model', function(){
                 expect(creditCardModal.Create).toHaveBeenCalled();
                 scope.$digest();
                 expect(toaster.success).toHaveBeenCalledWith('Credit Card Created', 'Success');
-                expect(state.reload).toHaveBeenCalledWith('myPayments');
+                expect(myPaymentCtrl.personalCreditCards).toEqual({Items:[mockCreditCard, "NEW_CREDIT_CARD"]});
             });
         });
         describe('Edit a Credit Card', function(){
             beforeEach(function(){
                 var df = q.defer();
-                df.resolve();
+                df.resolve("EDITED_CREDIT_CARD");
                 spyOn(creditCardModal, 'Edit').and.returnValue(df.promise);
-                myPaymentCtrl.edit(mockCreditCard);
+                myPaymentCtrl.edit({$index: 0, creditCard:mockCreditCard});
             });
-            it('should call the edit credit card modal then reload the state and display success toaster', function(){
+            it('should call the edit credit card modal then replace the old credit card in the array', function(){
                 expect(creditCardModal.Edit).toHaveBeenCalledWith(mockCreditCard);
                 scope.$digest();
                 expect(toaster.success).toHaveBeenCalledWith('Credit Card Updated', 'Success');
-                expect(state.reload).toHaveBeenCalledWith('myPayments');
+                expect(myPaymentCtrl.personalCreditCards).toEqual({Items:["EDITED_CREDIT_CARD"]});
             })
         });
         describe('Delete a Credit Card', function(){
@@ -130,7 +143,7 @@ describe('Component: myPayments', function() {
                 df.resolve();
                 spyOn(confirm, 'Confirm').and.returnValue(df.promise);
                 spyOn(authNet, 'DeleteCreditCard').and.returnValue(df.promise);
-                myPaymentCtrl.delete(mockCreditCard);
+                myPaymentCtrl.delete({$index:0, creditCard:mockCreditCard});
             });
             it('should call the delete credit card function, then  call Authorize.Net service , then reload the state and display success toaster', function(){
                 expect(confirm.Confirm).toHaveBeenCalledWith("Are you sure you want to delete this Credit Card?");
@@ -139,7 +152,7 @@ describe('Component: myPayments', function() {
                 expect(authNet.DeleteCreditCard).toHaveBeenCalled();
                 scope.$digest();
                 expect(toaster.success).toHaveBeenCalledWith('Credit Card Deleted', 'Success');
-                expect(state.reload).toHaveBeenCalledWith('myPayments');
+                expect(myPaymentCtrl.personalCreditCards).toEqual({Items: []});
             })
         })
 


### PR DESCRIPTION
Reducing the number of API calls by manipulating the view model rather than doing a $state.reload() when credit cards are created, updated, or removed.

Also removed an extra console.log from the oc-authnet.js service.