### PR TITLE
Bootswatch Themes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,8 @@
     "angular-tree-control": "^0.2.28",
     "angular-sticky": "angular-sticky-plugin#^0.3.0",
     "angular-busy2": "^5.2.0",
-    "angular-payments": "*"
+    "angular-payments": "*",
+    "bootswatch": "^3.3.7"
   },
   "devDependencies": {
     "angular-mocks": "^1.6.0"

--- a/gulp.config.js
+++ b/gulp.config.js
@@ -63,7 +63,8 @@ module.exports = {
         cascade: true
     },
     jsCache: 'jsscripts',
-    indentSize: 4
+    indentSize: 4,
+    checkBootswatchTheme: _checkBootswatchTheme
 };
 
 function getConstants() {
@@ -103,4 +104,20 @@ function getConstants() {
     if (process.env.buyerid) result.buyerid = process.env.buyerid;
     if (process.env.catalogid) result.catalogid = process.env.catalogid;
     return result;
+}
+
+function _checkBootswatchTheme() {
+    var bootswatchBower = {};
+    var constants = JSON.parse(fs.readFileSync(source + 'app/app.constants.json'));
+
+    var theme = process.env.bootswatchtheme || constants.bootswatchtheme;
+
+    if (theme) {
+        bootswatchBower.main = [
+            "./" + theme + "/bootswatch.less",
+            "./" + theme + "/variables.less"
+        ]
+    }
+
+    return bootswatchBower;
 }

--- a/gulp/build/styles.js
+++ b/gulp/build/styles.js
@@ -1,6 +1,5 @@
 var gulp = require('gulp'),
     config = require('../../gulp.config'),
-    browserSync = require('browser-sync').get('oc-server'),
     del = require('del'),
     less = require('gulp-less'),
     autoprefixer = require('gulp-autoprefixer'),
@@ -14,10 +13,17 @@ gulp.task('clean:styles', function() {
     return del(config.build + '**/*.css');
 });
 
-gulp.task('styles', ['clean:styles'], function() {
+gulp.task('styles', ['clean:styles'], StylesFunction);
+
+function StylesFunction() {
+    var browserSync = require('browser-sync').get('oc-server');
     return gulp
         .src([].concat(
-            mainBowerFiles({filter: '**/*.less'}),
+            mainBowerFiles({
+                filter: '**/*.less',
+                overrides: {
+                    'bootswatch': config.checkBootswatchTheme()
+                }}),
             './src/app/styles/main.less'
         ))
         .pipe(sourcemaps.init())
@@ -28,4 +34,6 @@ gulp.task('styles', ['clean:styles'], function() {
         .pipe(sourcemaps.write('../maps'))
         .pipe(gulp.dest(config.build + config.appCss))
         .pipe(browserSync.stream());
-});
+}
+
+module.exports = StylesFunction;

--- a/gulp/compile/app-css.js
+++ b/gulp/compile/app-css.js
@@ -20,7 +20,11 @@ gulp.task('app-css', ['clean:app-css'], function() {
 
     return gulp
         .src([].concat(
-            mainBowerFiles({filter: ['**/*.css', '**/*.less']}),
+            mainBowerFiles({
+                filter: ['**/*.css', '**/*.less'],
+                overrides: {
+                    'bootswatch': config.checkBootswatchTheme()
+                }}),
             './src/app/styles/main.less'
         ))
         .pipe(lessFilter)

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -4,6 +4,7 @@
     var nodemon = require('gulp-nodemon'),
         gulp = require('gulp'),
         config = require('../gulp.config'),
+        styles = require('./build/styles'),
         cache = require('gulp-cached'),
         browserSync = require('browser-sync').create('oc-server'),
         port = process.env.PORT || 7203;
@@ -41,7 +42,10 @@
                 config.styles
             ), ['styles']);
             gulp.watch(config.src + '**/app.constants.json', ['app-config'])
-                .on('change', browserSync.reload);
+                .on('change', function() {
+                    styles();
+                    return browserSync.reload;
+                });
         }
         return nodemon ({
             script: './server.js',

--- a/src/app/app.constants.json
+++ b/src/app/app.constants.json
@@ -6,5 +6,6 @@
   "catalogid": "XXXX",
   "environment": "prod",
   "defaultstate": "home",
-  "anonymous": false
+  "anonymous": false,
+  "bootswatchtheme": null
 }


### PR DESCRIPTION
Use any of the themes from [bootswatch](https://bootswatch.com/).

When working locally, use the `bootswatchtheme` variable in
`app.constants.json` to update your theme.  You can override any
of the theme's LESS from the `src/` directory.

On Heroku, use the config settings to set the same variable
for using different themes on any of your deployed applications.