### PR TITLE
workaround for spending account bug - EX-1053

### DIFF
--- a/src/app/checkout/payment/directives/payment.directives.js
+++ b/src/app/checkout/payment/directives/payment.directives.js
@@ -333,11 +333,15 @@ function PaymentsController($rootScope, $scope, $exceptionHandler, toastr, Order
 	};
 
 	$scope.removePayment = function(scope) {
-		OrderCloud.Payments.Delete($scope.order.ID, scope.payment.ID)
+		// TODO: when api bug EX-1053 is fixed refactor this to simply delete the payment
+		return OrderCloud.Payments.Patch($scope.order.ID, scope.payment.ID, {Type: 'PurchaseOrder', SpendingAccountID: null})
 			.then(function() {
-				$scope.payments.Items.splice(scope.$index, 1);
-				calculateMaxTotal();
-				toastr.success('Payment Removed');
+				return OrderCloud.Payments.Delete($scope.order.ID, scope.payment.ID)
+					.then(function(){
+						$scope.payments.Items.splice(scope.$index, 1);
+						calculateMaxTotal();
+						return toastr.success('Payment Removed');
+					});
 			});
 	};
 


### PR DESCRIPTION
When a payment with a type spending account is deleted the amount on that spending account gets added to the spending account. This workaround first patches the payment to type purchase order and then deletes it. Revert this back to just deleting the payment once the api bug has been resolved

Resolve: OC-2084