### PR TITLE
enable state loading if multiple parents

### DIFF
--- a/src/app/common/services/oc-state-loading/oc-state-loading.js
+++ b/src/app/common/services/oc-state-loading/oc-state-loading.js
@@ -12,9 +12,10 @@ angular.module('orderCloud')
         }
 
         function _init() {
-            $rootScope.$on('$stateChangeStart', function(e, toState) {
-                var parent = toState.parent || toState.name.split('.')[0];
-                stateLoading[parent] = $q.defer();
+            $rootScope.$on('$stateChangeStart', function(e, toState, toParams, fromState) {
+                var toParent = toState.parent || toState.name.split('.')[0];
+                var fromParent = fromState.parent || fromState.name.split('.')[0];
+                stateLoading[fromParent === toParent ? toParent : 'base'] = $q.defer();
             });
 
             $rootScope.$on('$stateChangeSuccess', function() {


### PR DESCRIPTION
if there are multiple parents (i.e. fromState.parent
does not equal toState.parent, then fallback to
base to host loading indicators