### PR TITLE
display missing images on review and confirmation

### DIFF
--- a/src/app/checkout/confirmation/templates/checkout.confirmation.html
+++ b/src/app/checkout/confirmation/templates/checkout.confirmation.html
@@ -92,7 +92,7 @@
 	<div class="row c-line-item" ng-repeat="lineItem in checkoutConfirmation.lineItems.Items track by $index">
 		<div class="col-xs-3 col-sm-2">
 			<div class="thumbnail c-line-item__img">
-				<img class="img-responsive" ng-src="{{lineItem.xp.image.URL || 'http://placehold.it/100x100?text=' + lineItem.Product.Name}}"
+				<img class="img-responsive" ng-src="{{lineItem.Product.xp.image.URL || 'http://placehold.it/100x100?text=' + lineItem.Product.Name}}"
 					 alt="{{lineItem.Product.xp.image.Name || 'Product Image'}}">
 			</div>
 		</div>

--- a/src/app/checkout/review/templates/checkout.review.html
+++ b/src/app/checkout/review/templates/checkout.review.html
@@ -41,7 +41,7 @@
 			<div class="row c-line-item" ng-repeat="lineItem in checkoutReview.lineItems.Items track by $index">
 				<div class="col-xs-3 col-sm-2">
 					<div class="thumbnail c-line-item__img">
-						<img class="img-responsive" ng-src="{{lineItem.xp.image.URL || 'http://placehold.it/100x100?text=' + lineItem.Product.Name}}"
+						<img class="img-responsive" ng-src="{{lineItem.Product.xp.image.URL || 'http://placehold.it/100x100?text=' + lineItem.Product.Name}}"
 							 alt="{{lineItem.Product.xp.image.Name || 'Product Image'}}">
 					</div>
 				</div>


### PR DESCRIPTION
These two views are always showing the placeholder
image for products, even when the product has an
image in it's extended properties.

OC-2151 #51