### PR TITLE
F51-154 and F51-177

### DIFF
--- a/src/app/myOrders/approvals/js/approvals.config.js
+++ b/src/app/myOrders/approvals/js/approvals.config.js
@@ -13,15 +13,11 @@ function ApprovalsConfig($stateProvider){
                 pageTitle: 'Order Approvals'
             },
             resolve: {
-                OrderApprovals: function($stateParams, ocApprovals) {
-                    return ocApprovals.List($stateParams.orderid, $stateParams.buyerid, 1, 100);
+                OrderApprovals: function($stateParams, ocApprovals, buyerid) {
+                    return ocApprovals.List($stateParams.orderid, buyerid);
                 },
                 CanApprove: function(CurrentUser, $stateParams, OrderCloudSDK){
-                    var parameters = {
-                        page: 1,
-                        pageSize: 100
-                    };
-                    return OrderCloudSDK.Orders.ListEligibleApprovers('outgoing', $stateParams.orderid, parameters)
+                    return OrderCloudSDK.Orders.ListEligibleApprovers('outgoing', $stateParams.orderid, {pageSize: 100})
                         .then(function(userList){
                             var userIDs = _.pluck(userList.Items, 'ID');
                             return userIDs.indexOf(CurrentUser.ID) > -1;

--- a/src/app/myOrders/approvals/js/approvals.controller.js
+++ b/src/app/myOrders/approvals/js/approvals.controller.js
@@ -8,21 +8,24 @@ function OrderApprovalsController($stateParams, ocApprovals, OrderApprovals, Can
     vm.list = OrderApprovals;
     vm.canApprove = CanApprove;
 
-    vm.pageChanged = function() {
-        ocApprovals.List($stateParams.orderid, $stateParams.buyerid, vm.list.Meta.Page, vm.list.Meta.PageSize)
+    vm.pageChanged = pageChanged;
+    vm.loadMore = loadMore;
+
+    function pageChanged() {
+        return ocApprovals.List($stateParams.orderid, $stateParams.buyerid, vm.list.Meta.Page, vm.list.Meta.PageSize)
             .then(function(data) {
                 vm.list = data;
             });
-    };
+    }
 
-    vm.loadMore = function() {
+    function loadMore() {
         vm.list.Meta.Page++;
-        ocApprovals.List($stateParams.orderid, $stateParams.buyerid, vm.list.Meta.Page, vm.list.Meta.PageSize)
+        return ocApprovals.List($stateParams.orderid, $stateParams.buyerid, vm.list.Meta.Page, vm.list.Meta.PageSize)
             .then(function(data) {
                 vm.list.Items = vm.list.Items.concat(data.Items);
                 vm.list.Meta = data.Meta;
             });
-    };
+    }
 
     vm.updateApprovalStatus = function(intent){
         //intent is a string either 'Approve' or 'Decline'

--- a/src/app/myOrders/approvals/js/approvals.service.js
+++ b/src/app/myOrders/approvals/js/approvals.service.js
@@ -46,7 +46,7 @@ function ocApprovals(OrderCloudSDK, $exceptionHandler, $uibModal, $state){
 
     function _updateApprovalStatus(orderID, intent){
         return $uibModal.open({
-            templateUrl: 'orders/orderApprovals/templates/approve.modal.html',
+            templateUrl: 'myOrders/approvals/templates/approve.modal.html',
             controller: 'ApprovalModalCtrl',
             controllerAs: 'approvalModal',
             size: 'md',

--- a/src/app/myOrders/approvals/js/approvals.service.js
+++ b/src/app/myOrders/approvals/js/approvals.service.js
@@ -2,83 +2,46 @@ angular.module('orderCloud')
     .factory('ocApprovals', ocApprovals)
 ;
 
-function ocApprovals($q, $uibModal, $state, OrderCloudSDK){
+function ocApprovals(OrderCloudSDK, $exceptionHandler, $uibModal, $state){
     var service = {
         List: _list,
         UpdateApprovalStatus: _updateApprovalStatus
     };
 
-    function _list(orderID, buyerID, page, pageSize) {
-        var deferred = $q.defer();
+    function _list(orderID, buyerID) {
 
-        var options = {
-            page: page,
-            pageSize: pageSize,
-            sortBy: 'Status'
-        };
-        OrderCloudSDK.Orders.ListApprovals('outgoing', orderID, options)
+        return OrderCloudSDK.Orders.ListApprovals('outgoing', orderID)
             .then(function(data) {
-                getApprovingUserGroups(data);
+                return getApprovingUserGroups(data);
             });
 
         function getApprovingUserGroups(data) {
             var userGroupIDs = _.uniq(_.pluck(data.Items, 'ApprovingGroupID'));
-            var options = {
-                page: 1,
-                pageSize: 100,
-                filters: {ID: userGroupIDs.join('|')}
-            };
-            OrderCloudSDK.UserGroups.List(buyerID, options)
+            return OrderCloudSDK.UserGroups.List(buyerID, {pageSize:100, filters: {ID: userGroupIDs.join('|')}})
                 .then(function(userGroupList) {
                     _.each(data.Items, function(approval) {
                         approval.ApprovingUserGroup = _.findWhere(userGroupList.Items, {ID: approval.ApprovingGroupID});
                     });
-                    getApprovingUsers(data);
+                    return getApprovalRules(data);
                 })
-                .catch(function() {
-                    getApprovingUsers(data);
-                });
-        }
-
-        function getApprovingUsers(data){
-            var userIDs = _.compact(_.uniq(_.pluck(data.Items, 'ApproverID')));
-            var options = {
-                page: 1,
-                pageSize: 100,
-                filters: {ID: userIDs.join('|')}
-            };
-            OrderCloudSDK.Users.List(buyerID, options)
-                .then(function(userList){
-                    _.each(data.Items, function(approval){
-                        if(approval.Status !== 'Pending') approval.ApprovingUser = _.findWhere(userList.Items, {ID: approval.ApproverID});
-                    });
-                    getApprovalRules(data);
-                })
-                .catch(function(){
-                    getApprovalRules(data);
+                .catch(function(ex) {
+                    return $exceptionHandler(ex);
                 });
         }
 
         function getApprovalRules(data) {
             var approvalRuleIDs = _.pluck(data.Items, 'ApprovalRuleID');
-            var options = {
-                page: 1,
-                pageSize: 100,
-                filters: {ID: approvalRuleIDs.join('|')}
-            };
-            OrderCloudSDK.ApprovalRules.List(buyerID, options)
+            return OrderCloudSDK.ApprovalRules.List(buyerID, {pageSize: 100, filters: {ID: approvalRuleIDs.join('|')}})
                 .then(function(approvalRuleData) {
                     angular.forEach(data.Items, function(approval) {
                         approval.ApprovalRule = _.findWhere(approvalRuleData.Items, {ID: approval.ApprovalRuleID});
                     });
-                    deferred.resolve(data);
+                    return data;
                 })
-                .catch(function() {
-                    deferred.resolve(data);
+                .catch(function(err) {
+                    return $exceptionHandler(err);
                 });
         }
-
-        return deferred.promise;
     }
 
     function _updateApprovalStatus(orderID, intent){

--- a/src/app/myOrders/approvals/templates/approvals.html
+++ b/src/app/myOrders/approvals/templates/approvals.html
@@ -51,7 +51,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="approval in orderApprovals.list.Items| filter:{Status:'Approved'}">
-                        <td>{{approval.ApprovingUser.FirstName + ' ' + approval.ApprovingUser.LastName}}</td>
+                        <td>{{approval.Approver.FirstName + ' ' + approval.Approver.LastName}}</td>
                         <td>{{approval.DateCompleted | date:'short'}}</td>
                         <td>{{approval.Comments}}</td>
                         <td>{{approval.ApprovalRule.Name}}</td>
@@ -80,7 +80,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="approval in orderApprovals.list.Items| filter:{Status:'Declined'}">
-                        <td>{{approval.ApprovingUser.FirstName + ' ' + approval.ApprovingUser.LastName}}</td>
+                        <td>{{approval.Approver.FirstName + ' ' + approval.Approver.LastName}}</td>
                         <td>{{approval.DateCompleted | date:'short'}}</td>
                         <td>{{approval.Comments}}</td>
                         <td>{{approval.ApprovalRule.Name}}</td>

--- a/src/app/myOrders/myOrders.md
+++ b/src/app/myOrders/myOrders.md
@@ -5,3 +5,16 @@ This component allows you to list, edit, and delete your orders.
 You can also list, edit and delete Line Items associated with the order in this component.
 
 MyOrders is a buyer specific admin component.
+
+
+### Approvals
+
+Note: This tab is only available to buyer users with the following roles:
+* Either: ApprovalRuleReader OR ApprovalRuleAdmin 
+    AND
+* Either : UserGroupReader OR UserGroupAdmin
+
+This tab allows you to receive any incoming orders awaiting your approval and act upon
+them by either Accepting or Declining the approval.
+
+An order can not continue to status: 'Complete' until all approval requirements have been met.

--- a/src/app/myOrders/order/templates/orderDetails.html
+++ b/src/app/myOrders/order/templates/orderDetails.html
@@ -20,10 +20,9 @@
         <li ui-sref-active="active">
             <a href="" ui-sref=".shipments"><i class="fa fa-truck"></i> Shipments</a>
         </li>
-        <!-- TODO: these roles seem incorrect in the api - fix when this is adjusted there -->
-        <!--<li ui-sref-active="active" oc-if-roles="['ApprovalRuleAdmin', 'AddressReader']">
+        <li ui-sref-active="active" oc-if-roles="ApprovalRuleRoles || UserGroupRoles">
             <a href="" ui-sref=".approvals"><i class="fa fa-check-square-o"></i> Approvals</a>
-        </li>-->
+        </li>
     </ul>
     <br>
     <div ui-view cg-busy="application.stateLoading('orderDetail')">

--- a/src/app/myOrders/orders/templates/orders.html
+++ b/src/app/myOrders/orders/templates/orders.html
@@ -6,7 +6,7 @@
         <nav>
             <ul class="nav nav-tabs aveda-nav-tabs">
                 <li role="presentation" ng-class="{active: orders.parameters.tab == 'history'}"><a ng-click="orders.selectTab('history')">Order History</a></li>
-                <li role="presentation" ng-class="{active: orders.parameters.tab == 'approvals'}"><a ng-click="orders.selectTab('approvals')">Awaiting Approval</a></li>
+                <li role="presentation" oc-if-roles="ApprovalRuleRoles || UserGroupRoles" ng-class="{active: orders.parameters.tab == 'approvals'}"><a ng-click="orders.selectTab('approvals')">Awaiting Approval</a></li>
                 <li role="presentation" ng-class="{active: orders.parameters.tab == 'favorites'}"><a ng-click="orders.selectTab('favorites')">Favorite Orders</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
- approval rule bugs & fixes:
  - modal template pointing to wrong location
  - remove function that gets users from approving user group. This is no longer necessary since approvals have an 'Approver' sub-object with user information
  - update template for new approver sub-object ^
  - hide approvals unless user has required roles - UserGroupRoles and ApprovalRuleRoles

- sync oc-if-roles with admin's