### PR TITLE
F51-214, F51-222 Anonymous Shopping

### DIFF
--- a/src/app/base/templates/base.html
+++ b/src/app/base/templates/base.html
@@ -12,6 +12,12 @@
         <li>
             <a ui-sref="categoryBrowse({page:'', sortBy:'', categoryID:''})">Category Browse</a>
         </li>
+        <li ng-if="base.currentUser.Anonymous">
+            <a ui-sref="login">Login</a>
+        </li>
+        <li ng-if="base.currentUser.Anonymous">
+            <a ui-sref="register">Register</a>
+        </li>
         <li uib-dropdown ng-if="!base.currentUser.Anonymous">
             <a uib-dropdown-toggle role="button">Account <span class="caret"></a>
             <ul class="dropdown-menu navmenu-nav" uib-dropdown-menu role="menu">
@@ -70,8 +76,15 @@
                     <a ui-sref="cart"><i class="fa fa-shopping-cart"></i> <span class="sr-only">Shopping Cart</span> <span class="badge" ng-bind="base.currentOrder.LineItemCount"></span></a>
                 </li>
             </ul>
-            <ul class="nav navbar-nav navbar-right c-desktop-nav" ng-if="!base.currentUser.Anonymous">
-                <li class="c-desktop-nav" uib-dropdown>
+            
+            <ul class="nav navbar-nav navbar-right c-desktop-nav">
+                <li ng-if="base.currentUser.Anonymous">
+                    <a ui-sref="login">Login</a>
+                </li>
+                <li ng-if="base.currentUser.Anonymous">
+                    <a ui-sref="register">Register</a>
+                </li>
+                <li class="c-desktop-nav" uib-dropdown  ng-if="!base.currentUser.Anonymous">
                     <a uib-dropdown-toggle role="button">Account <span class="caret"></span></a>
                     <ul class="dropdown-menu-right" uib-dropdown-menu>
                         <li>

--- a/src/app/cart/js/cart.controller.js
+++ b/src/app/cart/js/cart.controller.js
@@ -2,13 +2,14 @@ angular.module('orderCloud')
     .controller('CartCtrl', CartController)
 ;
 
-function CartController($rootScope, $state, toastr, OrderCloudSDK, LineItemsList, CurrentPromotions, ocConfirm) {
+function CartController($rootScope, $state, toastr, OrderCloudSDK, LineItemsList, CurrentPromotions, CurrentUser, ocConfirm, ocAnonymous) {
     var vm = this;
     vm.lineItems = LineItemsList;
     vm.promotions = CurrentPromotions.Meta ? CurrentPromotions.Items : CurrentPromotions;
     vm.removeItem = removeItem;
     vm.removePromotion = removePromotion;
     vm.cancelOrder = cancelOrder;
+    vm.proceedToCheckout = proceedToCheckout;
 
     $rootScope.$on('OC:UpdatePromotions', function(event, orderid) {
         return OrderCloudSDK.Orders.ListPromotions('outgoing', orderid)
@@ -50,5 +51,9 @@ function CartController($rootScope, $state, toastr, OrderCloudSDK, LineItemsList
                         $state.go('home', {}, {reload:'base'});
                     });
             });
+    }
+
+    function proceedToCheckout() {
+        $state.go('checkout.shipping');
     }
 }

--- a/src/app/cart/templates/cart.html
+++ b/src/app/cart/templates/cart.html
@@ -32,7 +32,7 @@
                         <span class="pull-right">- {{promotion.Amount | currency}}</span></h5>
                 </div>
                 <div class="panel-footer">
-                    <button ng-if="cart.lineItems.Items.length > 0" type="button" ui-sref="checkout.shipping" class="btn btn-block btn-primary" ng-disabled="OrderLineItemForm.$invalid">Proceed to Checkout</button>
+                    <button ng-if="cart.lineItems.Items.length > 0" type="button" ng-click="cart.proceedToCheckout()" class="btn btn-block btn-primary" ng-disabled="OrderLineItemForm.$invalid">Proceed to Checkout</button>
                 </div>
             </div>
         </aside>
@@ -108,7 +108,7 @@
             </div>
         </div>
         <div class="form-group">
-            <button ng-if="cart.lineItems.Items.length > 0" type="button" ui-sref="checkout.shipping"
+            <button ng-if="cart.lineItems.Items.length > 0" type="button" ng-click="cart.proceedToCheckout()"
                     class="btn btn-block btn-primary hidden-lg hidden-md">Proceed to Checkout</button>
         </div>
 </article>

--- a/src/app/checkout/js/checkout.config.js
+++ b/src/app/checkout/js/checkout.config.js
@@ -13,6 +13,26 @@ function CheckoutConfig($urlRouterProvider, $stateProvider) {
 			controller: 'CheckoutCtrl',
 			controllerAs: 'checkout',
 			resolve: {
+                IdentifyUser: function($state, ocAnonymous, CurrentUser) {
+                    if (CurrentUser.Anonymous) {
+                        ocAnonymous.Identify('checkout.shipping')
+                            .then(function(data) {
+                                //TODO: placeholder for guest checkout functionality
+                            })
+                            .catch(function(ex) {
+                                if (ex === 'LOGIN') {
+                                    $state.go('login');
+                                } else if (ex === 'REGISTER') {
+                                    $state.go('register');
+                                } else {
+                                    $state.go('cart');
+                                }
+                            });
+                    } else {
+                        ocAnonymous.RemoveRedirect();
+                        return;
+                    }
+                },
                 OrderShipAddress: function($q, OrderCloudSDK, CurrentOrder){
                     var deferred = $q.defer();
                     if (CurrentOrder.ShippingAddressID) {

--- a/src/app/checkout/js/checkout.config.js
+++ b/src/app/checkout/js/checkout.config.js
@@ -15,7 +15,7 @@ function CheckoutConfig($urlRouterProvider, $stateProvider) {
 			resolve: {
                 IdentifyUser: function($state, ocAnonymous, CurrentUser) {
                     if (CurrentUser.Anonymous) {
-                        ocAnonymous.Identify('checkout.shipping')
+                        ocAnonymous.Identify('cart')
                             .then(function(data) {
                                 //TODO: placeholder for guest checkout functionality
                             })
@@ -25,11 +25,11 @@ function CheckoutConfig($urlRouterProvider, $stateProvider) {
                                 } else if (ex === 'REGISTER') {
                                     $state.go('register');
                                 } else {
+                                    //User closed the modal
                                     $state.go('cart');
                                 }
                             });
                     } else {
-                        ocAnonymous.RemoveRedirect();
                         return;
                     }
                 },

--- a/src/app/checkout/review/templates/checkout.review.html
+++ b/src/app/checkout/review/templates/checkout.review.html
@@ -125,7 +125,7 @@
 					</div>
 				</div>
 				<div class="panel-footer">
-					<button type="button" class="btn btn-primary form-control" ng-disabled="false" ng-click="checkout.submitOrder(base.currentOrder)">Submit Order</button>
+					<button type="button" class="btn btn-primary btn-block" ng-disabled="false" ng-click="checkout.submitOrder(base.currentOrder)">Submit Order</button>
 				</div>
 			</div>
 		</div>

--- a/src/app/checkout/shipping/templates/checkout.shipping.html
+++ b/src/app/checkout/shipping/templates/checkout.shipping.html
@@ -58,7 +58,7 @@
                     <h4>Estimated Total: <b class="pull-right text-primary">{{base.currentOrder.Total | currency}}</b></h4>
                 </div>
                 <div class="panel-footer">
-                    <button type="button" class="btn btn-primary form-control" ng-disabled="!checkout.shippingAddress || checkoutShipping.shippersAreLoading || OC_Checkout_Shipping.$invalid" ui-sref="checkout.payment">Next</button>
+                    <button type="button" class="btn btn-primary btn-block" ng-disabled="!checkout.shippingAddress || checkoutShipping.shippersAreLoading || OC_Checkout_Shipping.$invalid" ui-sref="checkout.payment">Next</button>
                 </div>
             </div>
         </div>

--- a/src/app/common/config/error-handling/error-handling.js
+++ b/src/app/common/config/error-handling/error-handling.js
@@ -3,6 +3,7 @@ angular.module('orderCloud')
         //Error Handling
         $provide.value('ocErrorMessages', {
             customPassword: 'Password must be at least eight characters long and include at least one letter and one number',
+            ocMatch: 'Passwords do not match.',
             positiveInteger: 'Please enter a positive integer',
             ID_Name: 'Only Alphanumeric characters, hyphens and underscores are allowed',
             confirmpassword: 'Your passwords do not match',

--- a/src/app/common/directives/oc-match-field/oc-match-field.js
+++ b/src/app/common/directives/oc-match-field/oc-match-field.js
@@ -1,0 +1,18 @@
+angular.module('orderCloud')
+    .directive('ocMatchField', OrderCloudMatchFieldDirective)
+;
+
+function OrderCloudMatchFieldDirective() {
+    return {
+        scope: {
+            ocMatchField: '='
+        },
+        restrict: 'A',
+        require: 'ngModel',
+        link: function(scope, element, attr, ngModelCtrl) {
+            ngModelCtrl.$validators.ocMatch = function(val) {
+                return val === scope.ocMatchField;
+            };
+        }
+    };
+}

--- a/src/app/common/directives/oc-product-card/oc-product-card.js
+++ b/src/app/common/directives/oc-product-card/oc-product-card.js
@@ -22,6 +22,7 @@ function ocProductCard($rootScope, $scope, $exceptionHandler, $timeout, toastr, 
 
     $timeout(setDefaultQuantity, 100);
 
+    var toastID = 0; // This is used to circumvent the global toastr config that prevents duplicate toats from opening.
     vm.addToCart = function(OCProductForm) {
         var li = {
             ProductID: vm.product.ID,
@@ -33,7 +34,8 @@ function ocProductCard($rootScope, $scope, $exceptionHandler, $timeout, toastr, 
                 $rootScope.$broadcast('OC:UpdateOrder', vm.currentOrder.ID, 'Updating Order');
                 $rootScope.$broadcast('OC:UpdateTotalQuantity', li, true);
                 setDefaultQuantity();
-                toastr.success(vm.product.Name + ' was added to cart');
+                toastr.success(vm.product.Name + ' was added to your cart. <span class="hidden">' + vm.product.ID + toastID + '</span>', null, {allowHtml:true});
+                toastID++;
             })
             .catch(function(ex) {
                 $exceptionHandler(ex);

--- a/src/app/common/services/oc-anonymous/identify.modal.controller.js
+++ b/src/app/common/services/oc-anonymous/identify.modal.controller.js
@@ -1,0 +1,15 @@
+angular.module('orderCloud')
+    .controller('IdentifyModalCtrl', IdentifyModalController)
+;
+
+function IdentifyModalController($uibModalInstance, ocAppName) {
+    var vm = this;
+    vm.appName = ocAppName.Watch;
+    vm.cancel = $uibModalInstance.dismiss;
+    vm.login = function() {
+        $uibModalInstance.dismiss('LOGIN');
+    };
+    vm.register = function() {
+        $uibModalInstance.dismiss('REGISTER');
+    };
+}

--- a/src/app/common/services/oc-anonymous/identify.modal.html
+++ b/src/app/common/services/oc-anonymous/identify.modal.html
@@ -1,0 +1,35 @@
+<div class="modal-header">
+    <h4 class="modal-title">
+        <button type="button" class="close" aria-label="Close" ng-click="identifyModal.cancel()"><span aria-hidden="true">&times;</span></button>
+        An account is needed to continue
+    </h4>
+</div>
+<div class="modal-body">
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="panel panel-default" style="margin-bottom:0;">
+                <div class="panel-body text-center">
+                    <span>Already have an account?</span>
+                </div>
+                <div class="panel-footer">
+                    <button class="btn btn-default btn-block" ng-click="identifyModal.login()">
+                        Login now
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-6">
+            <hr class="visible-xs">
+            <div class="panel panel-default" style="margin-bottom:0;">
+                <div class="panel-body text-center">
+                    <span>New to {{identifyModal.appName()}}?</span>
+                </div>
+                <div class="panel-footer">
+                    <button class="btn btn-primary btn-block" ng-click="identifyModal.register()">
+                        Create an account
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/common/services/oc-anonymous/oc-anonymous.js
+++ b/src/app/common/services/oc-anonymous/oc-anonymous.js
@@ -15,7 +15,14 @@ function OrderCloudAnonymousService($q, $state, $cookies, $uibModal, OrderCloudS
     function _redirect() {
         var returnstate = $cookies.get(returnStateCookieName);
         if (returnstate) {
-            $state.go(returnstate);
+            $state.go(returnstate)
+                .then(function() {
+                    _removeRedirect();
+                })
+                .catch(function() {
+                    _removeRedirect();
+                    $state.go(defaultstate);
+                });
         } else {
             $state.go(defaultstate);
         }

--- a/src/app/common/services/oc-anonymous/oc-anonymous.js
+++ b/src/app/common/services/oc-anonymous/oc-anonymous.js
@@ -1,0 +1,115 @@
+angular.module('orderCloud')
+    .factory('ocAnonymous', OrderCloudAnonymousService)
+;
+
+function OrderCloudAnonymousService($q, $state, $cookies, $uibModal, OrderCloudSDK, ocLineItems, ocAppName, defaultstate) {
+    var service = {
+        Redirect: _redirect,
+        RemoveRedirect: _removeRedirect,
+        Identify: _identify,
+        MergeOrders: _mergeOrders
+    };
+
+    var returnStateCookieName = ocAppName.Watch().replace(/ /g, '_').toLowerCase() + '.return_state';
+
+    function _redirect() {
+        var returnstate = $cookies.get(returnStateCookieName);
+        if (returnstate) {
+            $state.go(returnstate);
+        } else {
+            $state.go(defaultstate);
+        }
+    }
+
+    function _removeRedirect() {
+        $cookies.remove(returnStateCookieName);
+    }
+
+    function _identify(returnState) {
+        if (returnState) $cookies.put(returnStateCookieName, returnState);
+        return $uibModal.open({
+            templateUrl: 'common/services/oc-anonymous/identify.modal.html',
+            controller: 'IdentifyModalCtrl',
+            controllerAs: 'identifyModal'
+        }).result;
+    }
+
+
+    function _mergeOrders(anonymousToken) {
+        var df = $q.defer();
+        var transferLineItems = [];
+        var oldOrderID;
+        //get the users latest unsubmitted order & all the line items
+        if (!anonymousToken) {
+            df.resolve();
+        } else {
+            OrderCloudSDK.Me.ListOrders({page: 1, pageSize: 1, sortBy: '!DateCreated', filters: {Status: 'Unsubmitted'}})
+                .then(function(data) {
+                    if (data.Items.length) {
+                        oldOrderID = data.Items[0].ID;
+                        _checkLineItems();
+                    } else {
+                        _transferOrder();
+                    }
+                    data.Items[0];
+                });
+        }
+
+        function _checkLineItems() {
+            ocLineItems.ListAll(oldOrderID)
+                .then(function(lineItems){
+                    transferLineItems = lineItems;
+                    _transferOrder();
+                });
+        }
+
+        function _transferOrder() {
+            OrderCloudSDK.Me.TransferAnonUserOrder(anonymousToken)
+                .then(function() {
+                    if (transferLineItems.length) {
+                        //add the line items from the users old unsubmitted order to the newly transferred order
+                        _transferLineItems();
+                    } else if (oldOrderID) {
+                        //if no lineitems exist, delete the old unsubmitted order
+                        _deleteOldOrder();
+                    } else {
+                        df.resolve();
+                    }
+                });
+        }
+
+        function _transferLineItems() {
+            var queue = [];
+            //decode the anonymous token to get the orderid that was transferred to the current user
+            var newOrderID = JSON.parse(atob(anonymousToken.split('.')[1])).orderid;
+            angular.forEach(transferLineItems, function(li) {
+                queue.push((function() {
+                    var defer = $q.defer();
+                    OrderCloudSDK.LineItems.Create('outgoing', newOrderID, _.pick(li, 'ProductID', 'Quantity', 'Specs', 'DateAdded', 'xp'))
+                        .then(function() {
+                            defer.resolve();
+                        })
+                        .catch(function(ex) {
+                            defer.resolve(ex);
+                        });
+                    return defer.promise;
+                })());
+            });
+            $q.all(queue)
+                .then(function() {
+                    _deleteOldOrder();
+                });
+        }
+
+        function _deleteOldOrder() {
+            //delete the users old unsubmitted order
+            OrderCloudSDK.Orders.Delete('outgoing', oldOrderID)
+                .then(function() {
+                    df.resolve();
+                });
+        }
+        return df.promise;
+    }
+
+    return service;
+}

--- a/src/app/common/services/oc-refresh-token/oc-refresh-token.js
+++ b/src/app/common/services/oc-refresh-token/oc-refresh-token.js
@@ -7,7 +7,7 @@ function OrderCloudRefreshTokenService($exceptionHandler, $rootScope, $state, $l
         refreshToken();
     });
 
-    function refreshToken() {
+    function refreshToken(redirectState) {
         var token = OrderCloudSDK.GetRefreshToken() || null;
         if (token) {
             OrderCloudSDK.Auth.RefreshToken(token, clientid, scope)
@@ -41,7 +41,9 @@ function OrderCloudRefreshTokenService($exceptionHandler, $rootScope, $state, $l
         }
 
         function _redirect() {
-            if ($state.current.name === '') {
+            if (redirectState) {
+                $state.go(redirectState);
+            } else if ($state.current.name === '') {
                 $state.go(defaultstate);
             } else {
                 $state.go($state.current.name, {}, {reload:true});

--- a/src/app/common/services/oc-refresh-token/oc-refresh-token.js
+++ b/src/app/common/services/oc-refresh-token/oc-refresh-token.js
@@ -26,7 +26,9 @@ function OrderCloudRefreshTokenService($exceptionHandler, $rootScope, $state, $l
             OrderCloudSDK.Auth.Anonymous(clientid, scope)
                 .then(function(data) {
                     OrderCloudSDK.SetToken(data.access_token);
-                    if (data.refresh_token) OrderCloudSDK.SetRefreshToken(data.refresh_token);
+                    // Intentionally not storing the potential refresh_token because OrderCloud identifies this grant-type as not anonymous.
+                    // Basically, if we use the refresh token grant type to keep the anon user logged in, we lose the orderid property
+                    // on the users token that identifies them as anonymous in base.config.js
                     _redirect();
                 })
                 .catch(function(ex) {

--- a/src/app/common/services/oc-state-loading/oc-state-loading.js
+++ b/src/app/common/services/oc-state-loading/oc-state-loading.js
@@ -19,7 +19,7 @@ angular.module('orderCloud')
 
                 if(toState.name !== 'login' && !OrderCloudSDK.GetToken()) {
                     e.preventDefault();
-                    ocRefreshToken();
+                    ocRefreshToken(toState.name);
                 }
             });
 
@@ -29,8 +29,14 @@ angular.module('orderCloud')
             });
 
             $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
-                if (toState.name == _defaultState()) event.preventDefault(); //prevent infinite loop when error occurs on default state (otherwise in Routing config)
-                error.data ? $exceptionHandler(error) : $exceptionHandler({message:error});
+                if (toState.name === _defaultState()) event.preventDefault(); //prevent infinite loop when error occurs on default state (otherwise in Routing config)
+                if (error && error.data) {
+                    $exceptionHandler(error);
+                } else if (error) {
+                    $exceptionHandler({message:error});
+                } else {
+                    $exceptionHandler({message:'This view is unavailable.'});
+                }
                 _end();
             });
         }
@@ -44,7 +50,7 @@ angular.module('orderCloud')
                 if (stateLoading[key].promise && !stateLoading[key].promise.$cgBusyFulfilled) {
                     stateLoading[key].resolve();  //resolve leftover loading promises
                 }
-            })
+            });
         }
 
         return service;

--- a/src/app/login/js/login.controller.js
+++ b/src/app/login/js/login.controller.js
@@ -1,8 +1,9 @@
 angular.module('orderCloud')
     .controller('LoginCtrl', LoginController);
 
-function LoginController($window, $state, $stateParams, $exceptionHandler, ocRoles, OrderCloudSDK, scope, clientid, defaultstate) {
+function LoginController($window, $state, $stateParams, $exceptionHandler, ocRoles, ocAnonymous, OrderCloudSDK, scope, clientid, defaultstate, anonymous) {
     var vm = this;
+    vm.anonymousEnabled = anonymous;
     vm.credentials = {
         Username: null,
         Password: null
@@ -16,12 +17,19 @@ function LoginController($window, $state, $stateParams, $exceptionHandler, ocRol
     vm.submit = function () {
         vm.loading = OrderCloudSDK.Auth.Login(vm.credentials.Username, vm.credentials.Password, clientid, scope)
             .then(function (data) {
+                var anonymousToken = OrderCloudSDK.GetToken();
                 OrderCloudSDK.SetToken(data.access_token);
                 if (vm.rememberStatus && data['refresh_token']) OrderCloudSDK.SetRefreshToken(data['refresh_token']);
+
                 var roles = ocRoles.Set(data.access_token);
                 if (roles.length === 1 && roles[0] === 'PasswordReset') {
                     vm.token = data.access_token;
                     vm.form = 'resetByToken';
+                } else if (anonymous) {
+                    return ocAnonymous.MergeOrders(anonymousToken)
+                        .then(function() {
+                            ocAnonymous.Redirect();
+                        });
                 } else {
                     $state.go(defaultstate);
                 }

--- a/src/app/login/templates/login.html
+++ b/src/app/login/templates/login.html
@@ -2,12 +2,13 @@
 
     <!--LOGIN FORM-->
     <div ng-switch-when="login">
+        <a ui-sref="home" ng-if="login.anonymousEnabled" class="text-center"><h3>{{application.name()}}</h3></a>
         <div class="panel panel-default">
-            <form class="panel-body" name="LoginForm" ng-submit="login.submit()" oc-pretty-submit>
-                <h3 class="text-center">Buyer Login</h3>
+            <form class="panel-body" name="LoginForm" ng-submit="login.submit()" autocomplete="off" novalidate oc-pretty-submit>
+                <h3 class="text-center">{{login.anonymousEnabled ? 'Login' : application.name() + ' Login'}}</h3>
                 <div class="form-group">
                     <label for="Username" class="sr-only">Username</label>
-                    <input id="Username" type="text" class="form-control" placeholder="Username" autocapitalize="off" autocorrect="off" autocomplete="off" ng-model="login.credentials.Username" ng-required="true" />
+                    <input id="Username" type="text" class="form-control" placeholder="Username" autocapitalize="off" autofocus ng-model="login.credentials.Username" ng-required="true" />
                 </div>
                 <div class="form-group">
                     <label for="Password" class="sr-only">Password</label>
@@ -27,7 +28,8 @@
             </form>
         </div>
         <div class="text-center">
-            <a id="forgot_password" ng-click="login.setForm('forgot')">Forgot Password?</a>
+            <a id="forgot_password" ng-click="login.setForm('forgot')">Forgot Password?</a> <br><br>
+            <span ng-if="login.anonymousEnabled">New to {{application.name()}}? <a ui-sref="register">Register now</a></span>
         </div>
     </div>
 
@@ -63,9 +65,9 @@
                 </div>
                 <div class="form-group">
                     <label for="ConfirmPassword" class="sr-only">Confirm Password</label>
-                    <input type="password" class="form-control" id="ConfirmPassword" placeholder="Confirm New Password" ng-model="login.credentials.ConfirmPassword" ng-required="true" />
+                    <input type="password" class="form-control" id="ConfirmPassword" placeholder="Confirm New Password" ng-model="login.credentials.ConfirmPassword" oc-match-field="login.credentials.NewPassword" ng-required="true" />
                 </div>
-                <button type="submit" id="reset_submit" class="btn btn-primary btn-block" ng-disabled="login.credentials.NewPassword != login.credentials.ConfirmPassword">Submit</button>
+                <button type="submit" id="reset_submit" class="btn btn-primary btn-block">Submit</button>
             </form>
         </div>
     </div>
@@ -84,9 +86,9 @@
                 </div>
                 <div class="form-group">
                     <label for="ConfirmPassword" class="sr-only">Confirm Password</label>
-                    <input type="password" class="form-control" id="ConfirmPassword" placeholder="Confirm New Password" ng-model="login.credentials.ConfirmPassword" ng-required="true" />
+                    <input type="password" class="form-control" id="ConfirmPassword" placeholder="Confirm New Password" ng-model="login.credentials.ConfirmPassword" oc-match-field="login.credentials.NewPassword" ng-required="true" />
                 </div>
-                <button type="submit" id="reset_submit" class="btn btn-primary btn-block" ng-disabled="login.credentials.NewPassword != login.credentials.ConfirmPassword">Submit</button>
+                <button type="submit" id="reset_submit" class="btn btn-primary btn-block">Submit</button>
             </form>
         </div>
     </div>

--- a/src/app/productDetail/js/productDetail.controller.js
+++ b/src/app/productDetail/js/productDetail.controller.js
@@ -6,11 +6,13 @@ function ProductDetailController($exceptionHandler, Product, CurrentOrder, ocLin
     var vm = this;
     vm.item = Product;
     vm.finalPriceBreak = null;
-
+    
+    var toastID = 0; // This is used to circumvent the global toastr config that prevents duplicate toats from opening.
     vm.addToCart = function() {
         ocLineItems.AddItem(CurrentOrder, vm.item)
-            .then(function(){
-                toastr.success('Product successfully added to your cart.');
+            .then(function() {
+                toastr.success(vm.item.Name + ' was added to your cart. <span class="hidden">' + vm.item.ID + toastID + '</span>', null, {allowHtml:true});
+                toastID++;
             })
             .catch(function(error){
                $exceptionHandler(error);

--- a/src/app/productQuickView/js/productQuickView.controller.js
+++ b/src/app/productQuickView/js/productQuickView.controller.js
@@ -8,7 +8,8 @@ function ProductQuickViewController(toastr, $uibModalInstance, SelectedProduct, 
 	vm.addToCart = function() {
 		ocLineItems.AddItem(CurrentOrder, vm.item)
 			.then(function(){
-                toastr.success('Product successfully added to your cart.');
+                toastr.clear();
+                toastr.success(vm.item.Name + ' was added to your cart.');
 				$uibModalInstance.close();
 			});
 	};

--- a/src/app/register/js/register.config.js
+++ b/src/app/register/js/register.config.js
@@ -1,0 +1,13 @@
+angular.module('orderCloud')
+    .config(RegisterConfig)
+;
+
+function RegisterConfig($stateProvider) {
+    $stateProvider
+        .state('register', {
+            url: '/register',
+            templateUrl: 'register/templates/register.html',
+            controller: 'RegisterCtrl',
+            controllerAs: 'register'
+        });
+}

--- a/src/app/register/js/register.config.js
+++ b/src/app/register/js/register.config.js
@@ -8,6 +8,19 @@ function RegisterConfig($stateProvider) {
             url: '/register',
             templateUrl: 'register/templates/register.html',
             controller: 'RegisterCtrl',
-            controllerAs: 'register'
+            controllerAs: 'register',
+            resolve: {
+                IsAnonymous: function($q, OrderCloudSDK, anonymous) {
+                    var df = $q.defer();
+                    if (!anonymous) {
+                        df.reject('Registration is not available for this store.');
+                    } else if (!angular.isDefined(JSON.parse(atob(OrderCloudSDK.GetToken().split('.')[1])).orderid)) {
+                        df.reject('You are already logged in.');
+                    } else {
+                        df.resolve();
+                    }
+                    return df.promise;
+                }
+            }
         });
 }

--- a/src/app/register/js/register.controller.js
+++ b/src/app/register/js/register.controller.js
@@ -2,7 +2,7 @@ angular.module('orderCloud')
     .controller('RegisterCtrl', RegisterController)
 ;
 
-function RegisterController(OrderCloudSDK, ocAnonymous, clientid, scope) {
+function RegisterController($exceptionHandler, OrderCloudSDK, ocAnonymous, clientid, scope) {
     var vm = this;
     vm.info = {
         FirstName: null,
@@ -13,6 +13,10 @@ function RegisterController(OrderCloudSDK, ocAnonymous, clientid, scope) {
         Phone: null,
         Email: null,
         Active: true
+    };
+
+    vm.onUsernameChange = function() {
+        if (vm.form.Username.$error['User.UsernameMustBeUnique']) vm.form.Username.$setValidity('User.UsernameMustBeUnique', true);
     };
     
     vm.submit = function() {
@@ -29,8 +33,11 @@ function RegisterController(OrderCloudSDK, ocAnonymous, clientid, scope) {
                     });
             })
             .catch(function(ex) {
-                console.log(ex);
-                var orderid = 'FJk60Hhho0ac2yawaooKSQ';
+                if (ex.response && ex.response.body && ex.response.body.Errors.length && ex.response.body.Errors[0].ErrorCode === 'User.UsernameMustBeUnique') {
+                    vm.form.Username.$setValidity('User.UsernameMustBeUnique', false);
+                } else {
+                    $exceptionHandler(ex);
+                }
             });
 
     };

--- a/src/app/register/js/register.controller.js
+++ b/src/app/register/js/register.controller.js
@@ -1,0 +1,37 @@
+angular.module('orderCloud')
+    .controller('RegisterCtrl', RegisterController)
+;
+
+function RegisterController(OrderCloudSDK, ocAnonymous, clientid, scope) {
+    var vm = this;
+    vm.info = {
+        FirstName: null,
+        LastName: null,
+        Username: null,
+        Password: null,
+        ConfirmPassword: null,
+        Phone: null,
+        Email: null,
+        Active: true
+    };
+    
+    vm.submit = function() {
+        var anonymousToken = OrderCloudSDK.GetToken();
+        vm.loading = OrderCloudSDK.Me.Register(anonymousToken, vm.info)
+            .then(function() {
+                return OrderCloudSDK.Auth.Login(vm.info.Username, vm.info.Password, clientid, scope)
+                    .then(function(data) {
+                        OrderCloudSDK.SetToken(data.access_token);
+                        return OrderCloudSDK.Me.TransferAnonUserOrder(anonymousToken)
+                            .then(function() {
+                                ocAnonymous.Redirect();
+                            });
+                    });
+            })
+            .catch(function(ex) {
+                console.log(ex);
+                var orderid = 'FJk60Hhho0ac2yawaooKSQ';
+            });
+
+    };
+}

--- a/src/app/register/templates/register.html
+++ b/src/app/register/templates/register.html
@@ -20,7 +20,7 @@
                 </div>
                 <div class="form-group">
                     <label for="Username" class="sr-only">Username</label>
-                    <input id="Username" type="text" class="form-control" placeholder="Username" name="Username" autocapitalize="off" autocorrect="off" autocomplete="off" ng-model="register.info.Username" ng-required="true" />
+                    <input id="Username" type="text" class="form-control" placeholder="Username" name="Username" autocapitalize="off" autocorrect="off" autocomplete="off" ng-model="register.info.Username" ng-change="register.onUsernameChange()" ng-required="true" />
                 </div>
                 <div class="form-group">
                     <label for="Password" class="sr-only">Password</label>
@@ -38,7 +38,7 @@
                     <label for="Email" class="sr-only">Email Address</label>
                     <input id="Email" name="Email" type="email" placeholder="Email Address" class="form-control" ng-model="register.info.Email" required/>
                 </div>
-                <button id="submit_register" type="submit" class="btn btn-primary btn-block">Submit</button>
+                <button id="submit_register" type="submit" class="btn btn-primary btn-block" cg-busy="register.loading">Submit</button>
             </form>
         </div>
         <div class="text-center">

--- a/src/app/register/templates/register.html
+++ b/src/app/register/templates/register.html
@@ -1,0 +1,48 @@
+<main class="register">
+    <div>
+        <a ui-sref="home" class="text-center"><h3>{{application.name()}}</h3></a>
+        <div class="panel panel-default">
+            <form class="panel-body" name="register.form" ng-submit="register.submit()" autocomplete="off" novalidate>
+                <h3 class="text-center">Create your account</h3>
+                <div class="row">
+                    <div class="col-xs-6">
+                        <div class="form-group">
+                            <label for="FirstName" class="sr-only">First Name</label>
+                            <input id="FirstName" name="FirstName" placeholder="First Name" type="text" autofocus class="form-control" ng-model="register.info.FirstName" required/>
+                        </div>
+                    </div>
+                    <div class="col-xs-6">
+                        <div class="form-group">
+                            <label for="LastName" class="sr-only">Last Name</label>
+                            <input id="LastName" name="LastName" placeholder="Last Name" type="text" class="form-control" ng-model="register.info.LastName" required/>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="Username" class="sr-only">Username</label>
+                    <input id="Username" type="text" class="form-control" placeholder="Username" name="Username" autocapitalize="off" autocorrect="off" autocomplete="off" ng-model="register.info.Username" ng-required="true" />
+                </div>
+                <div class="form-group">
+                    <label for="Password" class="sr-only">Password</label>
+                    <input type="password" class="form-control" placeholder="Password" name="Password" id="Password" ng-model="register.info.Password" ng-required="true"  pattern='^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d!$%@#£€*?&]{8,}$' pattern-err-type="customPassword" />
+                </div>
+                <div class="form-group">
+                    <label for="ConfirmPassword" class="sr-only">Confirm Password</label>
+                    <input type="password" class="form-control" placeholder="Confirm Password" name="ConfirmPassword" id="ConfirmPassword" oc-match-field="register.info.Password" ng-model="register.info.ConfirmPassword" ng-required="true" />
+                </div>
+                <div class="form-group">
+                    <label for="Phone" class="sr-only">Phone Number</label>
+                    <input id="Phone" name="Phone" placeholder="Phone Number (Optional)" type="tel" class="form-control" ng-model="register.info.Phone" />
+                </div>
+                <div class="form-group">
+                    <label for="Email" class="sr-only">Email Address</label>
+                    <input id="Email" name="Email" type="email" placeholder="Email Address" class="form-control" ng-model="register.info.Email" required/>
+                </div>
+                <button id="submit_register" type="submit" class="btn btn-primary btn-block">Submit</button>
+            </form>
+        </div>
+        <div class="text-center">
+            Already have an account? <a ui-sref="login">Login</a>
+        </div>
+    </div>
+</main>

--- a/src/app/styles/pages/_register.less
+++ b/src/app/styles/pages/_register.less
@@ -1,0 +1,17 @@
+.register {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:fixed;
+  left:0;
+  right:0;
+  bottom:20%;
+  top:0;
+  > div {
+    width:375px;
+    flex:0 0 auto;
+  }
+  h3 {
+    margin-bottom:@grid-gutter-width;
+  }
+}

--- a/src/app/styles/pages/glob.less
+++ b/src/app/styles/pages/glob.less
@@ -1,2 +1,3 @@
 @import '_cart';
 @import '_login';
+@import '_register';


### PR DESCRIPTION
Summary of changes:
- When app.constants.json > anonymous is set to true, the `ocRefreshToken` service will attempt to authorize anonymously using the current clientid and scope constants.
- An error will be logged to the console if the clientid is not configured to work with anonymous authentication.
- Do not store anon refresh tokens: storing these tokens will trigger the refresh token workflow which does not correspond to an anonymous authentication.
- Comments have been added in the code explaining why we do not store the refresh tokens from the anonymous auth response.
- The /register component has been added. Anonymous users can access this at any time to profile themselves.
- The login.controller.js has been updated to merge anon orders with profiled users most recent unsubmitted order
- Checkout state has a resolve for opening up the `ocAnonymous.Identify()` modal which will force anon users to either login or register before continuing to checking out.
- ocAnonymous has a "Redirect" function for sending the newly profiled user to the state that was passed into the `ocAnonymous.Identify()` modal (usually "cart" but it could be anything)
- Remove the redirect cookie after a successful `ocAnonymous.Redirect()`
- Block the registration state from non-anonymous users & applications
- Fix undefined error blocking `ocStateLoading` from completing
- Add a redirectState argument to `ocRefreshToken(redirectState)` for controlling where the user is sent to after the new token is retrieved.
- Registration form validation for username conflicts.

See the commit messages for more details.

Additional tasks:
F51-236 - Allow duplicate toasts on add-to-cart