### PR TITLE
F51-332 - Introduce data.ignoreToken to login

### DIFF
--- a/src/app/common/services/oc-state-loading/oc-state-loading.js
+++ b/src/app/common/services/oc-state-loading/oc-state-loading.js
@@ -17,7 +17,7 @@ angular.module('orderCloud')
                 var fromParent = fromState.parent || fromState.name.split('.')[0];
                 stateLoading[fromParent === toParent ? toParent : 'base'] = $q.defer();
 
-                if(toState.name !== 'login' && !OrderCloudSDK.GetToken()) {
+                if((!toState.data || (toState.data && !toState.data.ignoreToken)) && !OrderCloudSDK.GetToken()) {
                     e.preventDefault();
                     ocRefreshToken(toState.name);
                 }

--- a/src/app/login/js/login.config.js
+++ b/src/app/login/js/login.config.js
@@ -8,7 +8,10 @@ function LoginConfig($stateProvider) {
             url: '/login',
             templateUrl: 'login/templates/login.html',
             controller: 'LoginCtrl',
-            controllerAs: 'login'
+            controllerAs: 'login',
+            data: {
+                ignoreToken: true
+            }
         })
     ;
 }


### PR DESCRIPTION
- Now when states have data.ignoreToken set to true, the state can be loaded without the presence of an access_token. This approach will make it easier to add new unauthenticated states in /saas later on.