### PR TITLE
chore: upgrade require-dir to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "q": "1.4.1",
     "request": "^2.81.0",
     "request-promise": "^4.2.0",
-    "require-dir": "0.3.0",
+    "require-dir": "0.3.2",
     "yargs": "6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this version is compatible with node8/npm5