### PR TITLE
remove event listener from base and add unit tests for oc-product-card

### DIFF
--- a/src/app/base/js/base.controller.js
+++ b/src/app/base/js/base.controller.js
@@ -2,13 +2,14 @@ angular.module('orderCloud')
     .controller('BaseCtrl', BaseController)
 ;
 
-function BaseController($rootScope, $state, OrderCloudSDK, ocProductSearch, CurrentUser, CurrentOrder, TotalQuantity) {
+function BaseController($scope, $state, OrderCloudSDK, ocProductSearch, CurrentUser, CurrentOrder, TotalQuantity, $log) {
     var vm = this;
     vm.currentUser = CurrentUser;
     vm.currentOrder = CurrentOrder;
     vm.totalQuantity = TotalQuantity;
 
     vm.mobileSearch = mobileSearch;
+    vm.updateLineItemQuantities = updateLineItemQuantities;
 
     function mobileSearch() {
         return ocProductSearch.Open()
@@ -21,33 +22,40 @@ function BaseController($rootScope, $state, OrderCloudSDK, ocProductSearch, Curr
             });
     }
 
-    $rootScope.$on('OC:UpdateOrder', function(event, OrderID, message) {
+    $scope.$on('OC:UpdateOrder', function(event, orderID, updateLI) {
         vm.orderLoading = {
-            message: message
+            message: 'Updating Order'
         };
-        vm.orderLoading.promise = OrderCloudSDK.Orders.Get('outgoing', OrderID)
+        if(updateLI && typeof updateLI.lineItems !== 'undefined') updateLineItemQuantities(updateLI);
+        vm.orderLoading.promise = OrderCloudSDK.Orders.Get('outgoing', orderID)
             .then(function(order) {
                 vm.currentOrder = order;
             });
     });
 
-    $rootScope.$on('OC:UpdateTotalQuantity', function(event, lineItems, add, difference) {
-        if (lineItems.length >= 1) {
-            var quantities = _.pluck(lineItems, 'Quantity');
+    function updateLineItemQuantities(updateObj){
+                
+        /**
+         * @param updateObj.lineItems - lineItem(s) to update, provide all or one to update
+         * @param userInfo.add (boolean) determines whether to add to running total
+         * @param userInfo.subtract (boolean) determines whether to subtract from running total
+         */
+
+        if(updateObj.lineItems.length > 1) {
+            //calculates total assuming all line items are provided
+            var quantities = _.pluck(updateObj.lineItems, 'Quantity');
             vm.totalQuantity = quantities.reduce(function(a, b) {return a + b;}, 0);
         } else {
-            var li = lineItems[0] || lineItems;
-            if (vm.totalQuantity) {
-                if (add) {
-                    var newQuantity = difference ? difference : li.Quantity;
-                    vm.totalQuantity = newQuantity + vm.totalQuantity || 0;
-                } else {
-                    var newQuantity = difference ? difference : li.Quantity;
-                    vm.totalQuantity = vm.totalQuantity - newQuantity || 0;
-                }
+            //lineItems is a single value that wil be added or subtracted from total
+            var li = updateObj.lineItems[0] || updateObj.lineItems;
+
+            if(updateObj.add){
+                vm.totalQuantity += li.Quantity;
+            } else if(updateObj.subtract) {
+                vm.totalQuantity -= li.Quantity || 0;
             } else {
-                vm.totalQuantity = li.Quantity || 0;
+                $log.error('When updating a single line item, add or remove must be included in updateObject');
             }
-        }  
-    })
+        }
+    }
 }

--- a/src/app/base/tests/base.spec.js
+++ b/src/app/base/tests/base.spec.js
@@ -44,16 +44,18 @@ describe('Component: Base', function() {
         })
     });
 
-    describe('Controller: BaseCtrl', function(){
+   describe('Controller: BaseCtrl', function(){
         var baseCtrl;
         beforeEach(inject(function($controller) {
             baseCtrl = $controller('BaseCtrl', {
+                $scope: scope,
                 CurrentUser: mock.User,
                 CurrentOrder: mock.Order,
                 TotalQuantity: 3
             });
         }));
         it('should initialize the current user and order into its scope', function() {
+
             expect(baseCtrl.currentUser).toBe(mock.User);
             expect(baseCtrl.currentOrder).toBe(mock.Order);
         });

--- a/src/app/cart/js/cart.controller.js
+++ b/src/app/cart/js/cart.controller.js
@@ -2,7 +2,7 @@ angular.module('orderCloud')
     .controller('CartCtrl', CartController)
 ;
 
-function CartController($rootScope, $state, toastr, OrderCloudSDK, LineItemsList, CurrentPromotions, CurrentUser, ocConfirm, ocAnonymous) {
+function CartController($rootScope, $scope, $state, toastr, OrderCloudSDK, LineItemsList, CurrentPromotions, ocConfirm) {
     var vm = this;
     vm.lineItems = LineItemsList;
     vm.promotions = CurrentPromotions.Meta ? CurrentPromotions.Items : CurrentPromotions;
@@ -26,9 +26,8 @@ function CartController($rootScope, $state, toastr, OrderCloudSDK, LineItemsList
         vm.lineLoading = [];
         vm.lineLoading[scope.$index] = OrderCloudSDK.LineItems.Delete('outgoing', order.ID, scope.lineItem.ID)
             .then(function () {
-                $rootScope.$broadcast('OC:UpdateOrder', order.ID);
+                $scope.$emit('OC:UpdateOrder', order.ID, {lineItems: scope.lineItem, subtract: true});
                 vm.lineItems.Items.splice(scope.$index, 1);
-                $rootScope.$broadcast('OC:UpdateTotalQuantity', vm.lineItems.Items, true);
                 toastr.success(scope.lineItem.Product.Name + ' was removed from your shopping cart.');
             });
     }
@@ -36,7 +35,7 @@ function CartController($rootScope, $state, toastr, OrderCloudSDK, LineItemsList
     function removePromotion(order, scope) {
         return OrderCloudSDK.Orders.RemovePromotion('outgoing', order.ID, scope.promotion.Code)
             .then(function() {
-                $rootScope.$broadcast('OC:UpdateOrder', order.ID);
+                $scope.$emit('OC:UpdateOrder', order.ID);
                 vm.promotions.splice(scope.$index, 1);
             });
     }

--- a/src/app/cart/templates/cart.html
+++ b/src/app/cart/templates/cart.html
@@ -57,7 +57,7 @@
                         <hr>
                     </div>
                 </div>
-                <div class="row c-line-item" ng-repeat="lineItem in cart.lineItems.Items track by $index" cg-busy="cart.lineLoading[$index]">
+                <div class="row c-line-item" ng-repeat="lineItem in cart.lineItems.Items track by lineItem.ID" cg-busy="cart.lineLoading[$index]">
                     <div class="col-xs-3 col-sm-2">
                         <div class="thumbnail c-line-item__img">
                             <img class="img-responsive" ng-src="{{lineItem.Product.xp.image.URL || 'http://placehold.it/100x100?text=' + lineItem.Product.Name}}"

--- a/src/app/cart/test/cart.spec.js
+++ b/src/app/cart/test/cart.spec.js
@@ -29,6 +29,7 @@ describe('Component: Cart', function() {
             }
         beforeEach(inject(function($controller) {
             cartController = $controller('CartCtrl', {
+                $scope: scope,
                 CurrentPromotions: promoList,
                 LineItemsList: lineItemsList
             });
@@ -53,7 +54,7 @@ describe('Component: Cart', function() {
         describe('vm.removeItem', function() {
             beforeEach(function() {
                 spyOn(oc.LineItems, 'Delete').and.returnValue(dummyPromise);
-                spyOn(rootScope, '$broadcast');
+                spyOn(scope, '$emit');
             });
             it('should delete the line item', function() {
                 var lineItem = angular.copy(lineItemsList.Items[0]); //list gets mutated after deletion so save copy
@@ -61,7 +62,7 @@ describe('Component: Cart', function() {
                 scope.$digest();
                 expect(oc.LineItems.Delete).toHaveBeenCalledWith('outgoing', mock.Order.ID, lineItem.ID);
                 scope.$digest();
-                expect(rootScope.$broadcast).toHaveBeenCalledWith('OC:UpdateOrder', mock.Order.ID);
+                expect(scope.$emit).toHaveBeenCalledWith('OC:UpdateOrder', mock.Order.ID, {lineItems: lineItem, subtract: true});
                 scope.$digest();
                 expect(cartController.lineItems.Items).toEqual([mock.LineItem]);
             });
@@ -70,7 +71,7 @@ describe('Component: Cart', function() {
         describe('vm.removePromotion', function(){
             beforeEach(function(){
                 spyOn(oc.Orders, 'RemovePromotion').and.returnValue(dummyPromise);
-                spyOn(rootScope, '$broadcast');
+                spyOn(scope, '$emit');
             });
             it('should call oc.Orders.RemovePromotion', function(){
                 var mockRequest = {$index: 0, promotion: mock.Promotion};
@@ -78,7 +79,7 @@ describe('Component: Cart', function() {
                 scope.$digest();
                 expect(oc.Orders.RemovePromotion).toHaveBeenCalledWith('outgoing', mock.Order.ID, mock.Promotion.Code);
                 scope.$digest();
-                expect(rootScope.$broadcast).toHaveBeenCalledWith('OC:UpdateOrder', mock.Order.ID);
+                expect(scope.$emit).toHaveBeenCalledWith('OC:UpdateOrder', mock.Order.ID);
             });
         });
 

--- a/src/app/checkout/js/checkout.controller.js
+++ b/src/app/checkout/js/checkout.controller.js
@@ -2,7 +2,7 @@ angular.module('orderCloud')
 	.controller('CheckoutCtrl', CheckoutController)
 ;
 
-function CheckoutController($exceptionHandler, $state, $rootScope, toastr, OrderCloudSDK, OrderShipAddress, CurrentPromotions, OrderBillingAddress, CheckoutConfig) {
+function CheckoutController($exceptionHandler, $state, $rootScope, $scope, toastr, OrderCloudSDK, OrderShipAddress, CurrentPromotions, OrderBillingAddress, CheckoutConfig) {
     var vm = this;
     vm.shippingAddress = OrderShipAddress;
     vm.billingAddress = OrderBillingAddress;
@@ -50,7 +50,7 @@ function CheckoutController($exceptionHandler, $state, $rootScope, toastr, Order
                 } else {
                     vm.promotions = data;
                 }
-                $rootScope.$broadcast('OC:UpdateOrder', orderid);
+                $scope.$emit('OC:UpdateOrder', orderid);
             });
     });
 }

--- a/src/app/checkout/shipping/js/shipping.controller.js
+++ b/src/app/checkout/shipping/js/shipping.controller.js
@@ -2,7 +2,7 @@ angular.module('orderCloud')
     .controller('CheckoutShippingCtrl', CheckoutShippingController)
 ;
 
-function CheckoutShippingController($exceptionHandler, $rootScope, toastr, OrderCloudSDK, ocMyAddresses, ocAddressSelect, ocShippingRates, CheckoutConfig) {
+function CheckoutShippingController($exceptionHandler, $rootScope, $scope, toastr, OrderCloudSDK, ocMyAddresses, ocAddressSelect, ocShippingRates, CheckoutConfig) {
     var vm = this;
     vm.createAddress = createAddress;
     vm.changeShippingAddress = changeShippingAddress;
@@ -67,7 +67,7 @@ function CheckoutShippingController($exceptionHandler, $rootScope, toastr, Order
     function shipperSelected(order) {
         ocShippingRates.ManageShipments(order, vm.shippingRates)
             .then(function() {
-                $rootScope.$broadcast('OC:UpdateOrder', order.ID);
+                $scope.$emit('OC:UpdateOrder', order.ID);
             });
     }
 }

--- a/src/app/common/directives/oc-product-card/oc-product-card.js
+++ b/src/app/common/directives/oc-product-card/oc-product-card.js
@@ -5,53 +5,55 @@ angular.module('orderCloud')
         controllerAs: 'productCard',
         bindings: {
             product: '<',
-            currentOrder: '=',
-            lineitemlist: '='
+            currentOrder: '<',
+            lineitemlist: '<'
         }
     });
 
-function ocProductCard($rootScope, $scope, $exceptionHandler, $timeout, toastr, OrderCloudSDK){
+function ocProductCard($scope, $exceptionHandler, toastr, OrderCloudSDK){
     var vm = this;
-
-    $timeout(_initialize, 100);
-
     var toastID = 0; // This is used to circumvent the global toastr config that prevents duplicate toasts from opening.
-    vm.addToCart = function(OCProductForm) {
+    
+    vm.$onInit = onInit;
+    vm.addToCart = addToCart;
+    vm.findPrice = findPrice;
+    vm.setDefaultQuantity = setDefaultQuantity;
+
+    function onInit() {
+        if (!vm.currentOrder) return;
+        if (vm.product.PriceSchedule && vm.product.PriceSchedule.PriceBreaks) {
+            $scope.$watch(function(){
+                return vm.product.Quantity;
+            }, function(newVal){
+                vm.findPrice(newVal);
+            });
+        }
+
+        vm.setDefaultQuantity();
+    }
+
+    function addToCart() {
         var li = {
             ProductID: vm.product.ID,
             Quantity: vm.product.Quantity
         };
 
         return OrderCloudSDK.LineItems.Create('outgoing', vm.currentOrder.ID, li)
-            .then(function(lineItem) {
-                $rootScope.$broadcast('OC:UpdateOrder', vm.currentOrder.ID, 'Updating Order');
-                $rootScope.$broadcast('OC:UpdateTotalQuantity', li, true);
-                setDefaultQuantity();
+            .then(function() {
+                $scope.$emit('OC:UpdateOrder', vm.currentOrder.ID, {lineItems: li, add: true});
+                vm.setDefaultQuantity();
                 toastr.success(vm.product.Name + ' was added to your cart. <span class="hidden">' + vm.product.ID + toastID + '</span>', null, {allowHtml:true});
                 toastID++;
             })
             .catch(function(ex) {
                 $exceptionHandler(ex);
             });
-    };
-
-    function _initialize() {
-        if (!vm.currentOrder) return;
-        if (vm.product.PriceSchedule && vm.product.PriceSchedule.PriceBreaks) {
-            $scope.$watch(function(){
-                return vm.product.Quantity;
-            }, function(newVal){
-                _findPrice(newVal);
-            });
-        }
-
-        setDefaultQuantity();
     }
 
-    function _findPrice(qty){
+    function findPrice(qty){
         if(qty){
             var finalPriceBreak = {};
-            angular.forEach(vm.product.PriceSchedule.PriceBreaks, function(priceBreak) {
+            _.each(vm.product.PriceSchedule.PriceBreaks, function(priceBreak) {
                 if (priceBreak.Quantity <= qty)
                 finalPriceBreak = angular.copy(priceBreak);
             });

--- a/src/app/common/directives/oc-product-card/tests/oc-product-card.spec.js
+++ b/src/app/common/directives/oc-product-card/tests/oc-product-card.spec.js
@@ -1,4 +1,4 @@
-fdescribe('Component: addPromotion', function(){
+describe('Component: addPromotion', function(){
     var ctrl,
     componentScope
     ;

--- a/src/app/common/directives/oc-product-card/tests/oc-product-card.spec.js
+++ b/src/app/common/directives/oc-product-card/tests/oc-product-card.spec.js
@@ -1,1 +1,106 @@
-//TODO: Fix Failing unit tests # F51-308
+describe('Component: addPromotion', function(){
+    var ctrl,
+    componentScope
+    ;
+    beforeEach(inject(function($componentController, $rootScope, $compile){
+        scope = $rootScope.$new();
+        scope.product = mock.Product;
+        scope.currentOrder = mock.Order;
+        scope.lineitemlist = {Items: mock.LineItem};
+        var element = $compile('<oc-favorite-product ></oc-favorite-product>')(scope);
+        scope.$digest();
+        componentScope = element.scope();
+        ctrl = $componentController('ocProductCard', {$scope: componentScope});
+    }));
+    describe('$onInit', function(){
+        beforeEach(function(){
+            spyOn(ctrl, 'setDefaultQuantity');
+            spyOn(ctrl, 'findPrice');
+            ctrl.product = {};
+            componentScope.vm = ctrl;
+        });
+        it('should call setDefaultQuantity', function(){
+            ctrl.$onInit();
+            expect(ctrl.setDefaultQuantity).toHaveBeenCalled();
+        });
+        it('should create a watch if price breaks are defined', function(){
+            var newQty = 2; var oldQty = 10;
+            ctrl.product = {PriceSchedule: {PriceBreaks: {Quantity: oldQty, Price: 3}}};
+            ctrl.$onInit();
+            ctrl.product.Quantity = newQty;
+            componentScope.$apply();
+            expect(ctrl.findPrice).toHaveBeenCalledWith(newQty);
+        })
+        it('should not create a watch if price breaks are not defined', function(){
+            var newQty = 2; var oldQty = 10;
+            ctrl.$onInit();
+            ctrl.product.Quantity = newQty;
+            componentScope.$apply();
+            expect(ctrl.findPrice).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('addToCart', function(){
+        var mockLI = {ProductID: mock.LineItem.ID, Quantity: mock.LineItem.Quantity};
+        beforeEach(function(){
+            spyOn(oc.LineItems, 'Create').and.returnValue(dummyPromise);
+            spyOn(ctrl, 'setDefaultQuantity');
+            spyOn(componentScope, '$emit').and.callThrough();
+            ctrl.currentOrder = mock.Order;
+            ctrl.product = mock.LineItem;
+        });
+        it('should call LineItems.Create', function(){
+            ctrl.addToCart();
+            expect(oc.LineItems.Create).toHaveBeenCalledWith('outgoing', mock.Order.ID, mockLI);
+        });
+        it('should emit OC:UpdateOrder event', function(){
+            ctrl.addToCart();
+            componentScope.$digest();
+            expect(componentScope.$emit).toHaveBeenCalledWith('OC:UpdateOrder', mock.Order.ID, {lineItems: mockLI, add: true})
+        });
+        it('should call setDefaultQuantity', function(){
+            ctrl.addToCart();
+            componentScope.$digest();
+            expect(ctrl.setDefaultQuantity).toHaveBeenCalled();
+        });
+    });
+
+    describe('findPrice', function(){
+        beforeEach(function(){
+            ctrl.calculatedPrice = null;
+            ctrl.product = {PriceSchedule: {PriceBreaks: [{Quantity: 1, Price: 5}, {Quantity: 2, Price: 3}]}};
+        });
+        it('should not call function if there is no qty parameter', function(){
+            ctrl.findPrice();
+            componentScope.$digest();
+            expect(ctrl.calculatedPrice).toBe(null);
+        });
+        it('given quantity 1 should give price 5', function(){
+            ctrl.findPrice(1);
+            componentScope.$digest();
+            expect(ctrl.calculatedPrice).toBe(5);
+        });
+        it('given quantity 5 should give price 15', function(){
+            ctrl.findPrice(5);
+            componentScope.$digest();
+            expect(ctrl.calculatedPrice).toBe(15);
+        });
+    });
+
+    describe('setDefaultQuantity', function(){
+        var minQty;
+        beforeEach(function(){
+            minQty = 2;
+            ctrl.product = {};
+        })
+        it('should set quantity to 1 if no MinQuantity exists on price schedule', function(){
+            ctrl.setDefaultQuantity();
+            expect(ctrl.product.Quantity).toBe(1);
+        })
+        it('should set quantity to MinQuantity if it exists on price schedule', function(){
+            ctrl.product = {PriceSchedule: {MinQuantity: minQty}};
+            ctrl.setDefaultQuantity();
+            expect(ctrl.product.Quantity).toBe(minQty);
+        })
+    });
+});

--- a/src/app/common/directives/oc-product-card/tests/oc-product-card.spec.js
+++ b/src/app/common/directives/oc-product-card/tests/oc-product-card.spec.js
@@ -1,4 +1,4 @@
-describe('Component: addPromotion', function(){
+fdescribe('Component: addPromotion', function(){
     var ctrl,
     componentScope
     ;
@@ -13,18 +13,30 @@ describe('Component: addPromotion', function(){
         ctrl = $componentController('ocProductCard', {$scope: componentScope});
     }));
     describe('$onInit', function(){
+        var newQty = 2;
+        var oldQty = 10;
         beforeEach(function(){
             spyOn(ctrl, 'setDefaultQuantity');
             spyOn(ctrl, 'findPrice');
             ctrl.product = {};
+            ctrl.currentOrder = mock.Order;
             componentScope.vm = ctrl;
         });
         it('should call setDefaultQuantity', function(){
             ctrl.$onInit();
+            ctrl.product.Quantity = newQty;
+            componentScope.$apply();
+            expect(ctrl.findPrice).not.toHaveBeenCalled();
             expect(ctrl.setDefaultQuantity).toHaveBeenCalled();
+            
+        });
+        it('should only init default quantities when there is a current order', function(){
+            delete ctrl.currentOrder;
+            ctrl.$onInit();
+            expect(ctrl.setDefaultQuantity).not.toHaveBeenCalled();
+            expect(ctrl)
         });
         it('should create a watch if price breaks are defined', function(){
-            var newQty = 2; var oldQty = 10;
             ctrl.product = {PriceSchedule: {PriceBreaks: {Quantity: oldQty, Price: 3}}};
             ctrl.$onInit();
             ctrl.product.Quantity = newQty;
@@ -32,7 +44,6 @@ describe('Component: addPromotion', function(){
             expect(ctrl.findPrice).toHaveBeenCalledWith(newQty);
         })
         it('should not create a watch if price breaks are not defined', function(){
-            var newQty = 2; var oldQty = 10;
             ctrl.$onInit();
             ctrl.product.Quantity = newQty;
             componentScope.$apply();

--- a/src/app/common/directives/oc-quantity-input/oc-quantity-input.js
+++ b/src/app/common/directives/oc-quantity-input/oc-quantity-input.js
@@ -1,7 +1,7 @@
 angular.module('orderCloud')
     .directive('ocQuantityInput', OCQuantityInput);
 
-function OCQuantityInput($log, $rootScope, $state, toastr, OrderCloudSDK) {
+function OCQuantityInput($log, $state, toastr, OrderCloudSDK) {
     return {
         scope: {
             product: '=',
@@ -17,8 +17,7 @@ function OCQuantityInput($log, $rootScope, $state, toastr, OrderCloudSDK) {
                 scope.item = scope.product;
                 scope.content = 'product';
             } else if (scope.lineitem) {
-                var difference;
-                var add;
+                var add, subtract;
                 var lineItem = angular.copy(scope.lineitem);
                 scope.item = scope.lineitem;
                 scope.content = 'lineitem';
@@ -33,15 +32,9 @@ function OCQuantityInput($log, $rootScope, $state, toastr, OrderCloudSDK) {
                                 scope.lineitem = data;
                                 if (typeof scope.onUpdate === 'function') scope.onUpdate(scope.lineitem);
                                 toastr.success(data.Product.Name + ' quantity updated to ' + data.Quantity);
-                                $rootScope.$broadcast('OC:UpdateOrder', scope.order.ID, 'Calculating Order Total');
-                                if (lineItem.Quantity > data.Quantity) {
-                                    difference = lineItem.Quantity - data.Quantity;
-                                    add = false
-                                } else {
-                                    difference = data.Quantity - lineItem.Quantity;
-                                    add = true;
-                                }
-                                $rootScope.$broadcast('OC:UpdateTotalQuantity', data, add, difference);
+
+                                lineItem.Quantity > data.Quantity ? subtract = true : add = true;
+                                scope.$emit('OC:UpdateOrder', scope.order.ID, {lineItems: lineItem, add: add, subtract: subtract});
                                 $state.go('cart', {}, {reload: true});
                             });
                     }

--- a/src/app/common/services/oc-lineitems/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems/oc-lineitems.js
@@ -45,8 +45,7 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK) {
         li.ShippingAddressID = isSingleShipping(order) ? getSingleShippingAddressID(order) : null;
         OrderCloudSDK.LineItems.Create('outgoing', order.ID, li)
             .then(function(lineItem) {
-                $rootScope.$broadcast('OC:UpdateOrder', order.ID);
-                $rootScope.$broadcast('OC:UpdateTotalQuantity', lineItem, true);
+                $rootScope.$emit('OC:UpdateOrder', order.ID, {lineItems: lineItem, add: true});
                 deferred.resolve();
             })
             .catch(function(error) {

--- a/src/global.spec.js
+++ b/src/global.spec.js
@@ -148,7 +148,11 @@ function _mockData() {
             Total: 100
         },
         LineItem: {
-            ID: 'LINEITEM_ID'
+            ID: 'LINEITEM_ID',
+            Product: {
+                ID: 'MOCK_PRODUCT_ID'
+            },
+            Quantity: 3
         },
         Payment: {
             ID: 'PAYMENT_ID',


### PR DESCRIPTION
- remove OC:UpdateTotalQuantity event listener from base. The update order event listener now -
- optionally takes in a lineitemUpdate obj to handle both scenarios.
- refactor the logic for updating line items count for clarity. added comments
- slight changes to oc-product-card to make it more testable
- unit tests for oc-product-card are now complete
