### PR TITLE
fix: prevent memory leaks in directives

### DIFF
--- a/src/app/common/directives/oc-favorite-order/oc-favorite-order.js
+++ b/src/app/common/directives/oc-favorite-order/oc-favorite-order.js
@@ -29,6 +29,11 @@ function ocFavoriteOrderDirective($exceptionHandler, OrderCloudSDK, toastr) {
                 }
             });
 
+            scope.$on('$destroy', function(){
+                //prevent memory leak
+                element.off('click');
+            });
+
             function addOrder(existingList) {
                 existingList.push(scope.ocFavoriteOrder.ID);
                 return OrderCloudSDK.Me.Patch({xp: {FavoriteOrders: existingList}})

--- a/src/app/common/directives/oc-file-upload/oc-file-upload.js
+++ b/src/app/common/directives/oc-file-upload/oc-file-upload.js
@@ -133,7 +133,11 @@ function ordercloudFileUpload($parse, ocFileReader, ocFilesService) {
             }
         }
 
-        element.bind('change', updateModel);
+        element.on('change', updateModel);
+        scope.$on('$destroy', function(){
+            //prevent memory leak
+            element.off('change');
+        });
     }
 
     return directive;

--- a/src/app/common/directives/oc-prevent-click/oc-prevent-click.js
+++ b/src/app/common/directives/oc-prevent-click/oc-prevent-click.js
@@ -4,9 +4,13 @@ angular.module('orderCloud')
 
 function OrderCloudPreventClickDirective(){
     return {
-        link: function($scope, element) {
+        link: function(scope, element) {
             element.on("click", function(e){
                 e.stopPropagation();
+            });
+            scope.$on('$destroy', function(){
+                //prevent memory leak
+                element.off('click');
             });
         }
     };

--- a/src/app/common/directives/oc-reorder/js/oc-reorder.directive.js
+++ b/src/app/common/directives/oc-reorder/js/oc-reorder.directive.js
@@ -27,6 +27,10 @@ function ocReorderDirective(ocReorder, $exceptionHandler, $compile) {
                         return ocReorder.Open(scope.currentOrderId, lineItems);
                     });
             });
+            scope.$on('$destroy', function(){
+                //prevent memory leak
+                element.off('click');
+            });
         }
     };
 }

--- a/src/app/favoriteProducts/js/favoriteProducts.directive.js
+++ b/src/app/favoriteProducts/js/favoriteProducts.directive.js
@@ -33,7 +33,7 @@ function OrderCloudFavoriteProductDirective($exceptionHandler, toastr, ocFavorit
                 element.addClass(scope.nonFavoriteClass);
             }
 
-            element.bind('click', function() {
+            element.on('click', function() {
                 ocFavoriteProducts.Toggle(scope.product.ID)
                     .then(function(wasAdded) {
                         if (wasAdded) {
@@ -49,6 +49,10 @@ function OrderCloudFavoriteProductDirective($exceptionHandler, toastr, ocFavorit
                     });
             });
 
+            scope.$on('$destroy', function(){
+                //prevent memory leak
+                element.off('click');
+            });
         }
     };
 }

--- a/src/app/productQuickView/js/productQuickView.directive.js
+++ b/src/app/productQuickView/js/productQuickView.directive.js
@@ -10,11 +10,13 @@ function OrderCloudProductQuickViewDirective(ocProductQuickView) {
 			currentOrder: '<'
         },
         link: function(scope, element, attrs) {
-            element.bind('click', function() {
-                ocProductQuickView.Open(scope.currentOrder, scope.product);
+            element.on('click', function() {
+                return ocProductQuickView.Open(scope.currentOrder, scope.product);
             });
-
+            scope.$on('destroy', function(){
+                element.off('click');
+            });
             element.css('cursor', 'pointer');
         }
-    }
+    };
 }


### PR DESCRIPTION
we must manually remove event listeners for
directives that are binding to an event
(element.on)

F51-435