### PR TITLE
delete unused code and fix ocLineItems unit tests

### DIFF
--- a/src/app/common/services/oc-lineitems/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems/oc-lineitems.js
@@ -2,11 +2,10 @@ angular.module('orderCloud')
     .factory('ocLineItems', LineItemFactory)
 ;
 
-function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK) {
+function LineItemFactory($rootScope, $q, OrderCloudSDK) {
     return {
         SpecConvert: _specConvert,
         AddItem: _addItem,
-        CustomShipping: _customShipping,
         UpdateShipping: _updateShipping,
         ListAll: _listAll
     };
@@ -53,7 +52,7 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK) {
             });
 
         function isSingleShipping(order) {
-            return _.pluck(order.LineItems, 'ShippingAddressID').length == 1;
+            return _.pluck(order.LineItems, 'ShippingAddressID').length === 1;
         }
 
         function getSingleShippingAddressID(order) {
@@ -63,30 +62,10 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK) {
         return deferred.promise;
     }
 
-    function _customShipping(Order, LineItem) {
-        var modalInstance = $uibModal.open({
-            animation: true,
-            templateUrl: 'common/lineitems/templates/shipping.html',
-            controller: 'LineItemModalCtrl',
-            controllerAs: 'liModal',
-            size: 'lg'
-        });
-
-        modalInstance.result
-            .then(function (address) {
-                address.ID = Math.floor(Math.random() * 1000000).toString();
-                OrderCloudSDK.LineItems.SetShippingAddress('outgoing', Order.ID, LineItem.ID, address)
-                    .then(function () {
-                        $rootScope.$broadcast('LineItemAddressUpdated', LineItem.ID, address);
-                    });
-            });
-    }
-
     function _updateShipping(Order, LineItem, AddressID) {
         OrderCloudSDK.Me.GetAddress(AddressID)
             .then(function (address) {
                 OrderCloudSDK.LineItems.SetShippingAddress('outgoing', Order.ID, LineItem.ID, address);
-                $rootScope.$broadcast('LineItemAddressUpdated', LineItem.ID, address);
             });
     }
 

--- a/src/app/common/services/oc-lineitems/oc-lineitems.spec.js
+++ b/src/app/common/services/oc-lineitems/oc-lineitems.spec.js
@@ -1,44 +1,123 @@
-//TODO: Fix Failing unit tests # F51-313
+describe('Service: ocLineItems', function() {
+    var ocLineItemsService;
+    beforeEach(inject(function(ocLineItems) {
+        ocLineItemsService = ocLineItems;
+    }));
+    
+    describe('Method: SpecConvert(specs)', function() {
+        var specModel;
+        beforeEach(function(){
+            specModel = {
+                ID: 123,
+                Value: 'RED',
+                DefaultValue: 'BLUE',
+                OptionID: 'ORANGE',
+                DefaultOptionID: 'BLACK',
+                Options: []
+            };
+            spyOn(ocLineItemsService, 'SpecConvert').and.callThrough();
+        })
+        describe('when there are no spec options', function(){
+            it('it should only include SpecID and Value', function(){
+                var expected = [{
+                    SpecID: specModel.ID,
+                    Value: specModel.Value
+                }]
+                expect(ocLineItemsService.SpecConvert([specModel])).toEqual(expected);
+            });
+            it('should use default value if value does not exist', function(){
+                delete specModel.Value;
+                var expected = [{
+                    SpecID: specModel.ID,
+                    Value: specModel.DefaultValue
+                }]
+                expect(ocLineItemsService.SpecConvert([specModel])).toEqual(expected);
+            });
+        });
+        describe('when there are spec options', function(){
+            var expected;
+            beforeEach(function(){
+                specModel.Options = ['MockOptions'];
+                expected = [{
+                    SpecID: specModel.ID,
+                    Value: specModel.Value,
+                    OptionID: specModel.OptionID
+                }]
+            });
+            it('should include option ID', function(){
+                expect(ocLineItemsService.SpecConvert([specModel])).toEqual(expected);
+            });
+            it('should use default option id if there is no option id', function(){
+                delete specModel.OptionID;
+                expected[0].OptionID = specModel.DefaultOptionID;
+                expect(ocLineItemsService.SpecConvert([specModel])).toEqual(expected);
+            });
+        });
+    });
 
-// describe('Factory: ocLineItem', function() {
-//     var scope,
-//         q,
-//         oc,
-//         _ocLineItems,
-//         order = {
-//             ID: "FAKE_ORDER_ID",
-//             LineItems: []
-//         },
-//         product = {
-//             ID: "FAKE_PRODUCT_ID",
-//             Quantity: 2
-//         };
-//     beforeEach(module('orderCloud'));
-//     beforeEach(module('orderCloud.sdk'));
-//     beforeEach(inject(function($rootScope, $q, OrderCloud, ocLineItems) {
-//         scope = $rootScope.$new();
-//         q = $q;
-//         oc = OrderCloud;
-//         _ocLineItems = ocLineItems;
-//     }));
-//     describe('AddItem', function() {
-//         it ('should start up a new $q.defer()', function() {
-//             spyOn(q, 'defer').and.callThrough();
-//             _ocLineItems.AddItem(order, product);
-//             expect(q.defer).toHaveBeenCalled();
-//         });
-//         it ('should call OrderCloud.LineItems.Create()', function() {
-//             var defer = q.defer();
-//             defer.resolve("NEW_LINE_ITEM");
-//             spyOn(oc.LineItems, 'Create').and.returnValue(defer.promise);
+    describe('Method: AddItem', function(){
+        beforeEach(function(){
+            var dfd = q.defer();
+            dfd.resolve(mock.LineItem);
+            spyOn(ocLineItemsService, 'SpecConvert').and.callThrough();
+            spyOn(oc.LineItems, 'Create').and.returnValue(dfd.promise);
+            mock.LineItem.Specs = [{ID: 123, Value: 'RED', Options: []}]
+        })
+        it('should call LineItems create', function(){
+            var li = {
+                ProductID: mock.LineItem.ID,
+                Quantity: mock.LineItem.Quantity,
+                Specs: [{
+                    SpecID: mock.LineItem.Specs[0].ID, 
+                    Value: mock.LineItem.Specs[0].Value
+                }],
+                ShippingAddressID: null
+            }
+            ocLineItemsService.AddItem(mock.Order, mock.LineItem);
+            expect(oc.LineItems.Create).toHaveBeenCalledWith('outgoing', mock.Order.ID, li)
+        })
+    });
 
-//             _ocLineItems.AddItem(order, product);
-//             expect(oc.LineItems.Create).toHaveBeenCalledWith(order.ID, {
-//                 ProductID: product.ID,
-//                 Quantity: product.Quantity,
-//                 Specs: [],
-//                 ShippingAddressID: null
-//             });
-//         });
-//     });
-// });
+    describe('Method: UpdateShipping', function(){
+        var mockAddressID = 'abc123';
+        var mockAddress = {
+            Name: 'John',
+            LastName: 'Smith',
+            Street1: '404 Pleasant Lane',
+            City: 'Des Moines',
+            State: 'IA',
+            Country: 'US'
+        }
+        beforeEach(function(){
+            spyOn(oc.Me, 'GetAddress').and.returnValue(q.when(mockAddress));
+            spyOn(oc.LineItems, 'SetShippingAddress');
+            ocLineItemsService.UpdateShipping(mock.Order, mock.LineItem, mockAddressID)
+        });
+        it('should get current users address', function(){
+            expect(oc.Me.GetAddress).toHaveBeenCalledWith(mockAddressID);
+        })
+        it('should set shipping address on the line item', function(){
+            scope.$digest();
+            expect(oc.LineItems.SetShippingAddress).toHaveBeenCalledWith('outgoing', mock.Order.ID, mock.LineItem.ID, mockAddress);
+        })
+    });
+
+    describe('Method: ListAll', function(){
+        it('should only call list more than once if there are additional pages of results', function(){
+            var listCall = {Meta: {Page: 1, TotalPages: 1}, Items: [{ID: 'LI1'}]};
+            spyOn(oc.LineItems, 'List').and.returnValue(q.when(listCall));
+            ocLineItemsService.ListAll(mock.Order.ID);
+            expect(oc.LineItems.List).toHaveBeenCalledWith('outgoing', mock.Order.ID, {page:1, pageSize: 100});
+            expect(oc.LineItems.List).toHaveBeenCalledTimes(1);
+        });
+        it('should only continue calling list until there are no additional results', function(){
+            pageOne = {Meta: {Page: 1, TotalPages: 2}, Items: mock.LI};
+            pageTwo = {Meta: {Page: 2, TotalPages: 2}, Items: mock.LI};
+
+            spyOn(oc.LineItems, 'List').and.returnValues(q.when(pageOne, q.when(pageTwo)));
+            ocLineItemsService.ListAll(mock.Order.ID);
+            scope.$digest();
+            expect(oc.LineItems.List).toHaveBeenCalledTimes(2);
+        })
+    });
+});


### PR DESCRIPTION
- remove customShipping method from ocLineItems. This is used on line item level shipping which hasn't been created and will likely differ from its current implementation. 
- update ocLineItems unit tests so that they are all passing
