### PR TITLE
Update oc-product-carousel directive

### DIFF
--- a/src/app/common/directives/oc-product-carousel/oc-product-carousel.html
+++ b/src/app/common/directives/oc-product-carousel/oc-product-carousel.html
@@ -1,8 +1,10 @@
-<div cg-busy="carouselLoading" ng-if="products && products.Items.length">
-    <h4 ng-bind-html="title"></h4>
-    <div id="ProductCarousel" class="row c-product-slider">
-        <div class="col-xs-12" ng-repeat="product in products.Items">
-            <oc-product-card class="c-product-card" product="product"></oc-product-card>
+<div cg-busy="carouselLoading">
+    <div ng-if="products && products.Items.length" ng-style="{opacity: loading ? 0 : 1, height: loading ? '200px' : 'auto'}">
+        <h4 ng-bind-html="title"></h4>
+        <div id="{{elementID}}" class="row c-product-slider">
+            <div class="col-xs-12" ng-repeat="product in products.Items">
+                <oc-product-card class="c-product-card" product="product"></oc-product-card>
+            </div>
         </div>
     </div>
 </div>

--- a/src/app/common/directives/oc-product-carousel/oc-product-carousel.js
+++ b/src/app/common/directives/oc-product-carousel/oc-product-carousel.js
@@ -12,7 +12,11 @@ function OrderCloudProductCarouselDirective() {
         restrict: 'E',
         templateUrl: 'common/directives/oc-product-carousel/oc-product-carousel.html',
         controller: function($scope, $timeout) {
+            var slickElement, slickOptions;
             this.$onInit = function() {
+                $scope.loading = true;
+                $scope.elementID = generateElementID();
+                
                 var defaultSlidesToShow = 6;
                 var defaultResponsiveOptions = [
                     {
@@ -48,11 +52,38 @@ function OrderCloudProductCarouselDirective() {
                     responsive: defaultResponsiveOptions,
                     slidesToShow: defaultSlidesToShow
                 };
-                var slickOptions = angular.extend(defaultOptions, $scope.options || {});
-                $scope.carouselLoading = $timeout(function() {
-                    var slickElement = $('#ProductCarousel');
+
+                slickOptions = angular.extend(defaultOptions, $scope.options || {});
+
+                //Generates a random ID to be used by the .c-product-carousel element 
+                //unique IDs are needed for multiple <oc-product-carousel></oc-product-carousel> on a single page
+                function generateElementID() {
+                    var S4 = function() {
+                        return (((1+Math.random())*0x10000)|0).toString(16).substring(1);
+                    };
+                    return (S4()+'_'+S4());
+                }
+                
+                function _initializeCarousel() {
+
+                    //Store the slick element
+                    slickElement = $('#' + $scope.elementID);
+
+                    //After the slick element is initialized, set loading to false to show the directive
+                    slickElement.on('init', function(slick) {
+                        $scope.loading = false;
+                    });
+
+                    //Initiate the slick carousel with the merged slick options object
                     slickElement.slick(slickOptions);
-                }, 300);
+                }
+
+                if ($scope.products && $scope.products.Items.length) {
+                    $scope.carouselLoading = $timeout(_initializeCarousel, 300);
+                } else {
+                    //If there are no products available, do not initialize the slick carousel.
+                    $scope.loading = false;
+                }
             };
         }
     };


### PR DESCRIPTION
- Support multiple carousels on a single page
- Better pre-loading flow  (hide the products until they are ready to be viewed in the slider)