### PR TITLE
call ocRefresh if token is expired

### DIFF
--- a/gulp.config.js
+++ b/gulp.config.js
@@ -95,6 +95,7 @@ function getConstants() {
     var result = {};
     var constants = JSON.parse(fs.readFileSync(source + 'app/app.constants.json'));
     var environment = process.env.environment || constants.environment;
+    var node_env = process.env.NODE_ENV || 'development';
     switch (environment) {
         case 'local':
             result.authurl = 'http://core.four51.com:11629';
@@ -132,6 +133,8 @@ function getConstants() {
     if (process.env.awssecretaccesskey) result.awssecretaccesskey = process.env.awssecretaccesskey;
     if (process.env.awsregion) result.awsregion = process.env.awsregion;
     if (process.env.awsbucket) result.awsbucket = process.env.awsbucket;
+    result.node_env = node_env;
+    result.environment = environment;
     return result;
 }
 

--- a/src/app/common/config/compile-options/compile-options.js
+++ b/src/app/common/config/compile-options/compile-options.js
@@ -1,0 +1,9 @@
+angular.module('orderCloud')
+//optimizations for production build
+//https://docs.angularjs.org/guide/production
+    .config(function($compileProvider, $injector){
+        var isDev = $injector.get('node_env') !== 'production';
+        $compileProvider.debugInfoEnabled(isDev);
+        $compileProvider.commentDirectivesEnabled(isDev);
+        $compileProvider.cssClassDirectivesEnabled(isDev);
+    });

--- a/src/app/common/services/oc-state-loading/oc-state-loading.js
+++ b/src/app/common/services/oc-state-loading/oc-state-loading.js
@@ -17,7 +17,13 @@ angular.module('orderCloud')
                 var fromParent = fromState.parent || fromState.name.split('.')[0];
                 stateLoading[fromParent === toParent ? toParent : 'base'] = $q.defer();
 
-                if((!toState.data || (toState.data && !toState.data.ignoreToken)) && !OrderCloudSDK.GetToken()) {
+                var token = OrderCloudSDK.GetToken();
+                if(token){
+                    var expiresIn = JSON.parse(atob(token.split('.')[1])).exp * 1000;
+                    var tokenExpired = expiresIn < Date.now();
+                }
+
+                if((!toState.data || (toState.data && !toState.data.ignoreToken)) && (!token || tokenExpired)){
                     e.preventDefault();
                     ocRefreshToken(toState.name);
                 }


### PR DESCRIPTION
- on every state change checks that token exists and has not expired, if it has will call ocRefresh
- add config for optimizing angular when on production. This will skip evaluating css directives and comment directives (which we don't use) and remove ng-scope classes