### PR TITLE
Display additional images below primary product image (#134)

### DIFF
--- a/src/app/productDetail/js/productDetail.controller.js
+++ b/src/app/productDetail/js/productDetail.controller.js
@@ -5,11 +5,15 @@ angular.module('orderCloud')
 function ProductDetailController($exceptionHandler, Product, RelatedProducts, CurrentOrder, ocLineItems, toastr) {
     var vm = this;
     vm.item = Product;
+    vm.item.xp.image && vm.item.xp.additionalImages ? vm.item.xp.additionalImages.unshift(vm.item.xp.image) : angular.noop();
     vm.finalPriceBreak = null;
     vm.relatedProducts = RelatedProducts;
+
+    vm.addToCart = addToCart;
+    vm.findPrice = findPrice;
     
-    var toastID = 0; // This is used to circumvent the global toastr config that prevents duplicate toats from opening.
-    vm.addToCart = function() {
+    var toastID = 0; // This is used to circumvent the global toastr config that prevents duplicate toastrs from opening.
+    function addToCart() {
         ocLineItems.AddItem(CurrentOrder, vm.item)
             .then(function() {
                 toastr.success(vm.item.Name + ' was added to your cart. <span class="hidden">' + vm.item.ID + toastID + '</span>', null, {allowHtml:true});
@@ -20,7 +24,7 @@ function ProductDetailController($exceptionHandler, Product, RelatedProducts, Cu
             });
     };
 
-    vm.findPrice = function(qty){
+    function findPrice(qty){
         angular.forEach(vm.item.PriceSchedule.PriceBreaks, function(priceBreak) {
             if (priceBreak.Quantity <= qty)
                 vm.finalPriceBreak = angular.copy(priceBreak);

--- a/src/app/productDetail/js/productDetail.images.directive.js
+++ b/src/app/productDetail/js/productDetail.images.directive.js
@@ -1,0 +1,91 @@
+angular.module('orderCloud')
+    .directive('ocProductImages', ocProductImages)
+    .controller('ProductImagesModalCtrl', ProductImagesModalCtrl)
+;
+
+function ocProductImages() {
+    return {
+        scope: {
+            product: '='
+        },
+        restrict: 'E',
+        templateUrl: 'productDetail/templates/productDetail.images.html',
+        controller: function($scope, $timeout, $uibModal) {
+            var responsiveOpts = [
+                {
+                    breakpoint: 768,
+                    settings: {
+                        slidesToShow: 3
+                    }
+                },
+                {
+                    breakpoint: 425,
+                    settings: {
+                        slidesToShow: 2
+                    }
+                }
+            ]
+            var slickMainOpts = {
+                arrows: false,
+                infinite: false,
+                slidesToShow: 1,
+                slidesToScroll: 1,
+                fade: true,
+                asNavFor: '#ImageNav'
+            };
+
+            var slickNavOpts = {
+                arrows: true,
+                infinite: false,
+                responsive: responsiveOpts,
+                slidesToShow: 4,
+                slidesToScroll: 1,
+                focusOnSelect: true,
+                asNavFor: '#ImageMain'
+            };
+            $scope.carouselLoading = $timeout(function() {
+                var slickMain = $('#ImageMain');
+                slickMain.slick(slickMainOpts);
+
+                var slickNav = $('#ImageNav');
+                slickNav.slick(slickNavOpts);
+            }, 300);
+
+            $scope.openImageModal = function(model, index) {
+                if($scope.product.xp.imageZoom) {
+                    return $uibModal.open({
+                    animation: true,
+                    backdrop: true,
+                    templateUrl: 'productDetail/templates/productDetail.images.modal.html',
+                    controller: 'ProductImagesModalCtrl',
+                    controllerAs: 'productImagesModal',
+                    size: 'lg',
+                    resolve: {
+                        Model: function() {
+                            return model; 
+                        },
+                        Index: function() {
+                            return index;
+                        }
+                    }}).result;
+                }
+            }
+        }
+    }
+}
+
+function ProductImagesModalCtrl(Model, Index, $uibModalInstance) {
+    var vm = this;
+    vm.additionalImages;
+    vm.defaultImage;
+    Model.length ? vm.additionalImages = Model : vm.defaultImage = Model;
+    vm.index = Index;
+    vm.interval = null;
+    vm.noWrap = false;
+
+    vm.close = close;
+
+    function close() {
+        $uibModalInstance.dismiss();
+    }
+}

--- a/src/app/productDetail/templates/productDetail.html
+++ b/src/app/productDetail/templates/productDetail.html
@@ -5,12 +5,10 @@
     <hr>
     <div class="row">
         <div class="col-md-6">
-            <!--PRODUCT IMAGE-->
-            <div class="thumbnail">
-                <img class="img-responsive" alt="{{productDetail.item.xp.image.Name || 'Product Image'}}"
-                     ng-src="{{productDetail.item.xp.image.URL || 'http://placehold.it/600x600?text=' + productDetail.item.Name}}">
-            </div>
+            <!-- PRODUCT IMAGES -->                        
+            <oc-product-images product="productDetail.item"></oc-product-images>
         </div>
+        <!-- PRODUCT INFORMATION -->
         <div class="col-md-6">
             <div class="panel panel-default" ng-if="productDetail.item.Description">
                 <div class="panel-heading">

--- a/src/app/productDetail/templates/productDetail.images.html
+++ b/src/app/productDetail/templates/productDetail.images.html
@@ -1,0 +1,23 @@
+<div cg-busy="carouselLoading">
+    <!--IMAGE CAROUSEL-->
+    <div ng-if="product.xp && product.xp.additionalImages && product.xp.additionalImages.length">
+        <div id="ImageMain" class="row c-product-slider">
+            <div class="col-xs-12 thumbnail" ng-repeat="images in product.xp.additionalImages track by $index">
+                <img ng-src="{{images.URL}}" ng-click="openImageModal(product.xp.additionalImages, $index)"/>
+            </div>
+        </div>
+        <br>
+        <div id="ImageNav" class="row c-product-slider">
+            <div class="col-xs-12 thumbnail" ng-repeat="images in product.xp.additionalImages track by $index">
+                <img ng-src="{{images.URL}}" />
+            </div>
+        </div>
+    </div>
+    <!--SINGLE IMAGE-->
+    <div ng-if="!product.xp.additionalImages || !product.xp.additionalImages.length">
+        <div class="thumbnail" ng-if="!product.xp.additionalImages || !product.xp.additionalImages.length">
+            <img class="img-responsive" alt="{{product.xp.image.Name || 'Product Image'}}"
+                    ng-src="{{product.xp.image.URL || 'http://placehold.it/600x600?text=' + product.Name}}" ng-click="openImageModal(product.xp.image, $index)">
+        </div>
+    </div>
+</div>

--- a/src/app/productDetail/templates/productDetail.images.modal.html
+++ b/src/app/productDetail/templates/productDetail.images.modal.html
@@ -1,0 +1,8 @@
+<div uib-carousel active="productImagesModal.index" interval="productImagesModal.interval" no-wrap="productImagesModal.noWrap">
+    <div ng-if="productImagesModal.additionalImages" uib-slide ng-repeat="images in productImagesModal.additionalImages track by $index" index="$index">
+        <img class="img-responsive" ng-src="{{images.URL}}" />
+    </div>
+    <div ng-if="productImagesModal.defaultImage">
+        <img class="img-responsive" ng-src="{{productImagesModal.defaultImage.URL}}" />
+    </div>
+</div>

--- a/src/app/styles/components/_carousel.less
+++ b/src/app/styles/components/_carousel.less
@@ -12,3 +12,12 @@
     }
   }
 }
+
+.modal-body .carousel-control {
+  background-image: none;
+  color: @slick-arrow-color;
+  opacity: @slick-opacity-default;
+  &:hover {
+    opacity: @slick-opacity-on-hover;
+  }
+}


### PR DESCRIPTION
* F51-386
feat: add slick carousel template for multiple product images

* F51-386
feat: repeat over product.xp.Images

* F51-386
refactor: comment out responsive breakpoint, add infinite false to slick carousel

* F51-386
refactor: add template request to directive

* F51-386
chore: add angular-ez-plus, zoom library

* F51-386
refactor: add timeout function in directive

* F51-386
feat: product zoom using ez-plus directive

* reset branch to previous commit

* reset branch to previous commit

* refactor: wrap template request in timeout, add center-mode attr to slick carousel nav

* refactor: add modal for product images

F51-386

* refactor: update the slick carousel usage to a directive

* refactor: move product images carousel and modal functionality into directive
F51-386

* F51-386

feat: add zoom directive (wip) for products

* F51-386
refactor: update code to reflect data structure of additional images on product

* F51-386
refactor: add conditional to open zoom modal if zoom enabled on product

* F51-386
refactor: remove use of oc-zoom directive

* F51-386
refactor: remove scope injection

* F51-386
refactor: move inline style on thumbnail for product slider to less file

* F51-386
refactor: remove empty style declaration

* F51-386
refactor: remove commented out code

* F51-386
refactor: move single image to images directive, update modal to be compatible with one image

* F51-386
refactor: remove inline style

* F51-386
refactor: remove redundant style, fix size on modal config